### PR TITLE
Update Expo commands to use npx in package.json scripts

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "main": "expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios"
+    "start": "npx expo start",
+    "android": "npx expo run:android",
+    "ios": "npx expo run:ios"
   },
   "dependencies": {
     "expo": "~51.0.22",


### PR DESCRIPTION
Replace legacy expo-cli commands with npx for starting and running the Expo application.