### PR TITLE
Fix release workflow to use semantic-release with Yarn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
           cache: "yarn"
       - run: corepack enable
       - run: yarn install --frozen-lockfile
+      - run: yarn add -D semantic-release @semantic-release/changelog @semantic-release/commit-analyzer @semantic-release/git @semantic-release/github @semantic-release/release-notes-generator semantic-release-yarn
 
-      - run: npx semantic-release
+      - run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: corepack enable
       - run: yarn install --frozen-lockfile
 
-      - run: npx semantic-release@21.0.2
+      - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
     "@semantic-release/changelog",
     [
-      "@semantic-release/npm",
+      "semantic-release-yarn",
       {
         npmPublish: true,
       },


### PR DESCRIPTION
Update the release workflow to utilize semantic-release without version pinning and switch to Yarn for dependency management, incorporating necessary plugins for improved functionality.