### PR TITLE
Implement delete session functionality

### DIFF
--- a/ios/AsleepModule.swift
+++ b/ios/AsleepModule.swift
@@ -92,6 +92,15 @@ public class AsleepModule: Module {
             return dictionary
         }
 
+        AsyncFunction("deleteSession") { (sessionId: String) -> Void in
+            guard let reportManager = self.reportManager else {
+                throw NSError(domain: "AsleepModule", code: 2, userInfo: [NSLocalizedDescriptionKey: "Reports not initialized"])
+            }
+            sendEvent("onDebugLog", ["message": "deleteSession: \(sessionId)"])
+            try await reportManager.deleteReport(sessionId: sessionId)
+            sendEvent("onDebugLog", ["message": "deleteSession completed"])
+        }
+
         Function("isTracking") { () -> Bool in
             return trackingManager?.getTrackingStatus().sessionId != nil
         }

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -38,6 +38,7 @@ export interface AsleepState {
   stopTracking: () => Promise<void>;
   getReport: (sessionId: string) => Promise<AsleepReport | null>;
   getReportList: (fromDate: string, toDate: string) => Promise<AsleepSession[]>;
+  deleteSession: (sessionId: string) => Promise<void>;
   requestMicrophonePermission: () => Promise<boolean>;
   setCustomNotification: (title: string, text: string) => Promise<void>;
   enableLog: (print: boolean) => void;
@@ -278,6 +279,21 @@ export const useAsleepStore = create<AsleepState>()(
         console.error("getReportList error:", error);
         set({ error: error.message });
         return [];
+      }
+    },
+
+    deleteSession: async (sessionId: string) => {
+      try {
+        const { addLog } = get();
+        addLog(`[deleteSession] sessionId: ${sessionId}`);
+
+        await AsleepModule.deleteSession(sessionId);
+
+        addLog("[deleteSession] Success");
+      } catch (error: any) {
+        console.error("deleteSession error:", error);
+        set({ error: error.message });
+        throw error;
       }
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,10 @@ class Asleep {
     return reportList.map(this.convertKeysToCamelCase);
   };
 
+  deleteSession = async (sessionId: string): Promise<void> => {
+    return AsleepModule.deleteSession(sessionId);
+  };
+
   requestMicrophonePermission = async (): Promise<boolean> => {
     return AsleepModule.requestMicrophonePermission();
   };
@@ -143,6 +147,7 @@ export const useAsleep = () => {
     stopTracking,
     getReport,
     getReportList,
+    deleteSession,
     enableLog,
     setCustomNotification,
     requestAnalysis,
@@ -176,6 +181,7 @@ export const useAsleep = () => {
     stopTracking,
     getReport,
     getReportList,
+    deleteSession,
     requestAnalysis,
     isODAEnabled,
     analysisResult,
@@ -205,6 +211,9 @@ export const AsleepSDK = {
 
   getReportList: (fromDate: string, toDate: string) =>
     useAsleepStore.getState().getReportList(fromDate, toDate),
+
+  deleteSession: (sessionId: string) =>
+    useAsleepStore.getState().deleteSession(sessionId),
 
   requestAnalysis: () => useAsleepStore.getState().requestAnalysis(),
 


### PR DESCRIPTION
## Summary
- Implement delete session functionality across TypeScript, iOS, and Android layers
- Add example usage in the demo app with confirmation dialog

## Changes
- Add `deleteSession` method to Asleep class, useAsleep hook, and AsleepSDK singleton
- Implement deleteSession in AsleepStore with proper error handling and logging
- Add native deleteSession implementation for iOS using `reportManager.deleteReport()`
- Add native deleteSession implementation for Android with `DeleteReportListener`
- Update example app to demonstrate delete session feature with confirmation dialog
- Add delete button in report detail view that refreshes report list after deletion

## Test Plan
- [ ] Test delete session on iOS simulator/device
- [ ] Test delete session on Android emulator/device
- [ ] Verify session is removed from report list after deletion
- [ ] Verify error handling when deleting non-existent session
- [ ] Verify confirmation dialog works properly

🤖 Generated with [Claude Code](https://claude.ai/code)