### PR TITLE
Update iOS SDK to v3.1.4

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -9,6 +9,7 @@ import {
   View,
   Modal,
   TouchableOpacity,
+  Platform,
 } from "react-native";
 import { useTracking } from "./useTracking";
 import { useAsleep } from "react-native-asleep/src";
@@ -59,6 +60,14 @@ const App = () => {
       addLog(`Error: ${error}`);
     }
   }, [error]);
+
+  // Watch for analysis result changes (for iOS)
+  useEffect(() => {
+    if (analysisResult) {
+      addLog(`Analysis result received: ${JSON.stringify(analysisResult)}`);
+      // Don't automatically show modal since analysis is called periodically
+    }
+  }, [analysisResult]);
 
   useEffect(() => {
     let interval: NodeJS.Timeout;
@@ -158,8 +167,7 @@ const App = () => {
 
       const reportList = await getReportList(fromDate, toDate);
       addLog(
-        `Retrieved ${
-          Array.isArray(reportList) ? reportList.length : "unknown"
+        `Retrieved ${Array.isArray(reportList) ? reportList.length : "unknown"
         } reports`
       );
 
@@ -177,8 +185,19 @@ const App = () => {
     try {
       const result = await requestAnalysis();
       if (result) {
-        addLog(`Analysis result: ${JSON.stringify(result)}`);
-        showModal("Analysis Result", result);
+        addLog(`Request analysis response: ${JSON.stringify(result)}`);
+
+        // For Android, show the result immediately
+        if (Platform.OS === 'android' && result.sleepStages) {
+          showModal("Analysis Result", result);
+        } else if (Platform.OS === 'ios') {
+          // For iOS, show the current analysisResult if available
+          if (analysisResult) {
+            showModal("Analysis Result", analysisResult);
+          } else {
+            addLog("No analysis result available yet");
+          }
+        }
       } else {
         addLog("No analysis result available");
       }
@@ -205,16 +224,27 @@ const App = () => {
           )}
 
           <Text style={styles.modalSectionTitle}>Basic Information</Text>
-          <Text>Session ID: {report.sessionId || "N/A"}</Text>
-          <Text>User ID: {report.userId || "N/A"}</Text>
+          <Text>Session ID: {report.session?.id || report.sessionId || "N/A"}</Text>
+          <Text>User ID: {userId || "N/A"}</Text>
           <Text>
-            Date: {report.createdAt || report.sessionStartTime || "N/A"}
+            Start Time: {report.session?.startTime || report.sessionStartTime || "N/A"}
           </Text>
-          <Text>State: {report.state || "N/A"}</Text>
+          <Text>
+            End Time: {report.session?.endTime || report.sessionEndTime || "N/A"}
+          </Text>
+          <Text>State: {report.session?.state || report.state || "N/A"}</Text>
           <Text>
             Time in Bed:{" "}
-            {report.timeInBed ? `${report.timeInBed} minutes` : "N/A"}
+            {report.stat?.timeInBed 
+              ? `${Math.round(report.stat.timeInBed / 60)} minutes` 
+              : report.timeInBed 
+              ? `${report.timeInBed} minutes` 
+              : "N/A"}
           </Text>
+          {report.timezone && <Text>Timezone: {report.timezone}</Text>}
+          {report.missingDataRatio !== undefined && (
+            <Text>Missing Data Ratio: {(report.missingDataRatio * 100).toFixed(1)}%</Text>
+          )}
 
           {report.stat && (
             <>
@@ -353,8 +383,8 @@ const App = () => {
             {!isTracking
               ? "Not Tracking"
               : isTrackingPaused
-              ? "Paused"
-              : "Active"}
+                ? "Paused"
+                : "Active"}
           </Text>
           <Text>ODA Enabled: {isODAEnabled ? "Yes" : "No"}</Text>
           <Text>Analysis Status: {isAnalyzing ? "Yes" : "No"}</Text>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Asleep (1.0.0):
-    - AsleepSDK (= 3.1.3)
+    - AsleepSDK (= 3.1.4)
     - ExpoModulesCore
-  - AsleepSDK (3.1.3)
+  - AsleepSDK (3.1.4)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - EXConstants (17.1.6):
@@ -1970,84 +1970,84 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Asleep: 5a13fe1664861724128854471949c9752c58c80a
-  AsleepSDK: 5dd9d4f671e8176f3b6baf9a2ef7da2ae39a1ed3
+  Asleep: 76977dd1757fe6964bb52e3c29a5973865110db8
+  AsleepSDK: c167167e5b40fe80a8aeaf8b512cd87644bd9df7
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
-  Expo: 77b39f42396989cbe6fbef9f6fafc9b35186a95b
-  ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
-  ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
-  ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
-  ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
-  ExpoModulesCore: e2e363bcdee87b46f858586d1887ebb215582001
+  EXConstants: 9f310f44bfedba09087042756802040e464323c0
+  Expo: 4e8bda07d30b024b1732f87843a5349a3ecc1316
+  ExpoAsset: 3bc9adb7dbbf27ae82c18ca97eb988a3ae7e73b1
+  ExpoFileSystem: c36eb8155eb2381c83dda7dc210e3eec332368b6
+  ExpoFont: abbb91a911eb961652c2b0a22eef801860425ed6
+  ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
+  ExpoModulesCore: d431ffe83c8673d02cb38425594a5f5480fd3061
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 84b955f7b4da8b895faf5946f73748267347c975
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e
   RCTTypeSafety: 659ae318c09de0477fd27bbc9e140071c7ea5c93
   React: c2d3aa44c49bb34e4dfd49d3ee92da5ebacc1c1c
   React-callinvoker: 1bdfb7549b5af266d85757193b5069f60659ef9d
-  React-Core: 7150cf9b6a5af063b37003062689f1691e79c020
-  React-CoreModules: 15a85e6665d61678942da6ae485b351f4c699049
-  React-cxxreact: 74f9de59259ac951923f5726aa14f0398f167af9
+  React-Core: 10597593fdbae06f0089881e025a172e51d4a769
+  React-CoreModules: 6907b255529dd46895cf687daa67b24484a612c2
+  React-cxxreact: a9f5b8180d6955bc3f6a3fcd657c4d9b4d95c1f6
   React-debug: e74e76912b91e08d580c481c34881899ccf63da9
-  React-defaultsnativemodule: 628285212bbd65417d40ad6a9f8781830fda6c98
-  React-domnativemodule: 185d9808198405c176784aaf33403d713bd24fb7
-  React-Fabric: c814804affbe1952e16149ddd20256e1bccae67e
-  React-FabricComponents: 81ef47d596966121784afec9924f9562a29b1691
-  React-FabricImage: f14f371d678aa557101def954ac3ba27e48948ff
+  React-defaultsnativemodule: 11f6ee2cf69bf3af9d0f28a6253def33d21b5266
+  React-domnativemodule: f940bbc4fa9e134190acbf3a4a9f95621b5a8f51
+  React-Fabric: 6f5c357bf3a42ff11f8844ad3fc7a1eb04f4b9de
+  React-FabricComponents: 10e0c0209822ac9e69412913a8af1ca33573379b
+  React-FabricImage: f582e764072dfa4715ae8c42979a5bace9cbcc12
   React-featureflags: d5facceff8f8f6de430e0acecf4979a9a0839ba9
-  React-featureflagsnativemodule: 96f0ab285382d95c90f663e02526a5ceefa95a11
-  React-graphics: 1a66ee0a3f093b125b853f6370296fadcaf6f233
-  React-hermes: 8b86e5f54a65ecb69cdf22b3a00a11562eda82d2
-  React-idlecallbacksnativemodule: 5c25ab145c602264d00cb26a397ab52e0efa031c
-  React-ImageManager: 15e34bd5ef1ac4a18e96660817ef70a7f99ee8c2
-  React-jserrorhandler: 02cdf2cd45350108be1ffd2b164578936dbbdff7
-  React-jsi: 6af1987cfbb1b6621664fdbf6c7b62bd4d38c923
-  React-jsiexecutor: 51f372998e0303585cb0317232b938d694663cbd
-  React-jsinspector: 3539ad976d073bfaa8a7d2fa9bef35e70e55033e
-  React-jsinspectortracing: e8dbacaf67c201f23052ca1c2bae2f7b84dec443
-  React-jsitooling: 95a34f41e3c249d42181de13b4f8d854f178ca9f
-  React-jsitracing: 25b029cf5cad488252d46da19dd8c4c134fd5fe4
-  React-logger: 368570a253f00879a1e4fea24ed4047e72e7bbf3
-  React-Mapbuffer: c04fcda1c6281fc0a6824c7dcc1633dd217ac1ec
-  React-microtasksnativemodule: ca2804a25fdcefffa0aa942aa23ab53b99614a34
-  React-NativeModulesApple: 452b86b29fae99ed0a4015dca3ad9cd222f88abf
+  React-featureflagsnativemodule: a7dd141f1ef4b7c1331af0035689fbc742a49ff4
+  React-graphics: 36ae3407172c1c77cea29265d2b12b90aaef6aa0
+  React-hermes: 9116d4e6d07abeb519a2852672de087f44da8f12
+  React-idlecallbacksnativemodule: ae7f5ffc6cf2d2058b007b78248e5b08172ad5c3
+  React-ImageManager: 9daee0dc99ad6a001d4b9e691fbf37107e2b7b54
+  React-jserrorhandler: 1e6211581071edaf4ecd5303147328120c73f4dc
+  React-jsi: 753ba30c902f3a41fa7f956aca8eea3317a44ee6
+  React-jsiexecutor: 47520714aa7d9589c51c0f3713dfbfca4895d4f9
+  React-jsinspector: cfd27107f6d6f1076a57d88c932401251560fe5f
+  React-jsinspectortracing: 76a7d791f3c0c09a0d2bf6f46dfb0e79a4fcc0ac
+  React-jsitooling: 995e826570dd58f802251490486ebd3244a037ab
+  React-jsitracing: 094ae3d8c123cea67b50211c945b7c0443d3e97b
+  React-logger: 8edfcedc100544791cd82692ca5a574240a16219
+  React-Mapbuffer: c3f4b608e4a59dd2f6a416ef4d47a14400194468
+  React-microtasksnativemodule: 054f34e9b82f02bd40f09cebd4083828b5b2beb6
+  React-NativeModulesApple: 2c4377e139522c3d73f5df582e4f051a838ff25e
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c
-  React-perflogger: 6fd2f6811533e9c19a61e855c3033eecbf4ad2a0
-  React-performancetimeline: abf31259d794c9274b3ea19c5016186925eec6c4
+  React-perflogger: 9a151e0b4c933c9205fd648c246506a83f31395d
+  React-performancetimeline: 5b0dfc0acba29ea0269ddb34cd6dd59d3b8a1c66
   React-RCTActionSheet: a499b0d6d9793886b67ba3e16046a3fef2cdbbc3
-  React-RCTAnimation: 2595dcb10a82216a511b54742f8c28d793852ac6
-  React-RCTAppDelegate: f03604b70f57c9469a84a159d8abecf793a5bcff
-  React-RCTBlob: e00f9b4e2f151938f4d9864cf33ebf24ac03328a
-  React-RCTFabric: 3945d116fd271598db262d4e6ed5691d431ed9e8
-  React-RCTFBReactNativeSpec: 0f4d4f0da938101f2ca9d5333a8f46e527ad2819
-  React-RCTImage: dac5e9f8ec476aefe6e60ee640ebc1dfaf1a4dbe
-  React-RCTLinking: 494b785a40d952a1dfbe712f43214376e5f0e408
-  React-RCTNetwork: b3d7c30cd21793e268db107dd0980cb61b3c1c44
-  React-RCTRuntime: a8ff419d437228e7b8a793b14f9d711e1cbb82af
-  React-RCTSettings: a060c7e381a3896104761b8eed7e284d95e37df3
-  React-RCTText: 4f272b72dbb61f390d8c8274528f9fdbff983806
-  React-RCTVibration: 0e5326220719aca12473d703aa46693e3b4ce67a
+  React-RCTAnimation: cc64adc259aabc3354b73065e2231d796dfce576
+  React-RCTAppDelegate: 9d523da768f1c9e84c5f3b7e3624d097dfb0e16b
+  React-RCTBlob: e727f53eeefded7e6432eb76bd22b57bc880e5d1
+  React-RCTFabric: 58590aa4fdb4ad546c06a7449b486cf6844e991f
+  React-RCTFBReactNativeSpec: 9064c63d99e467a3893e328ba3612745c3c3a338
+  React-RCTImage: 7159cbdbb18a09d97ba1a611416eced75b3ccb29
+  React-RCTLinking: 46293afdb859bccc63e1d3dedc6901a3c04ef360
+  React-RCTNetwork: 4a6cd18f5bcd0363657789c64043123a896b1170
+  React-RCTRuntime: 5ab904fd749aa52f267ef771d265612582a17880
+  React-RCTSettings: 61e361dc85136d1cb0e148b7541993d2ee950ea7
+  React-RCTText: abd1e196c3167175e6baef18199c6d9d8ac54b4e
+  React-RCTVibration: 490e0dcb01a3fe4a0dfb7bc51ad5856d8b84f343
   React-rendererconsistency: 351fdbc5c1fe4da24243d939094a80f0e149c7a1
-  React-renderercss: d333f2ada83969591100d91ec6b23ca2e17e1507
-  React-rendererdebug: 039e5949b72ba63c703de020701e3fd152434c61
+  React-renderercss: 3438814bee838ae7840a633ab085ac81699fd5cf
+  React-rendererdebug: 0ac2b9419ad6f88444f066d4b476180af311fb1e
   React-rncore: 57ed480649bb678d8bdc386d20fee8bf2b0c307c
-  React-RuntimeApple: 344a5e1105256000afabaa8df12c3e4cab880340
-  React-RuntimeCore: 0e48fb5e5160acc0334c7a723a42d42cef4b58b6
+  React-RuntimeApple: 8b7a9788f31548298ba1990620fe06b40de65ad7
+  React-RuntimeCore: e03d96fbd57ce69fd9bca8c925942194a5126dbc
   React-runtimeexecutor: d60846710facedd1edb70c08b738119b3ee2c6c2
-  React-RuntimeHermes: 064286a03871d932c99738e0f8ef854962ab4b99
-  React-runtimescheduler: e917ab17ae08c204af1ebf8f669b7e411b0220c8
+  React-RuntimeHermes: aab794755d9f6efd249b61f3af4417296904e3ba
+  React-runtimescheduler: c3cd124fa5db7c37f601ee49ca0d97019acd8788
   React-timing: a90f4654cbda9c628614f9bee68967f1768bd6a5
-  React-utils: 51c4e71608b8133fecc9a15801d244ae7bdf3758
-  ReactAppDependencyProvider: d5dcc564f129632276bd3184e60f053fcd574d6b
-  ReactCodegen: fda99a79c866370190e162083a35602fdc314e5d
-  ReactCommon: 4d0da92a5eb8da86c08e3ec34bd23ab439fb2461
+  React-utils: a612d50555b6f0f90c74b7d79954019ad47f5de6
+  ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
+  ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
+  ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 

--- a/ios/Asleep.podspec
+++ b/ios/Asleep.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'AsleepSDK', '3.1.3'
+  s.dependency 'AsleepSDK', '3.1.4'
 
 
   # Swift/Objective-C compatibility

--- a/ios/AsleepModule.swift
+++ b/ios/AsleepModule.swift
@@ -123,7 +123,6 @@ public class AsleepModule: Module {
                 "status": "requested",
                 "timestamp": Date().timeIntervalSince1970 * 1000
             ]
-            
             return ackData
         }
     }
@@ -163,7 +162,25 @@ extension AsleepModule: AsleepConfigDelegate {
 extension AsleepModule: AsleepSleepTrackingManagerDelegate {
     public func didFail(error: Asleep.AsleepError) {
         sendEvent("onDebugLog", ["message": "Tracking failed: \(error)"])
-        sendEvent("onTrackingFailed", ["error": error.localizedDescription])
+        
+        var errorInfo: [String: Any] = ["error": error.localizedDescription]
+        
+        // Add specific error codes for new v3.1.4 error cases
+        switch error {
+        case .ODAIntegrityFail:
+            errorInfo["code"] = "ODA_INTEGRITY_FAIL"
+            errorInfo["message"] = "The model has been updated or the file is corrupted"
+        case .networkOffline:
+            errorInfo["code"] = "NETWORK_OFFLINE"
+            errorInfo["message"] = "The Internet connection appears to be offline"
+        case .unableODA:
+            errorInfo["code"] = "UNABLE_ODA"
+            errorInfo["message"] = "On-device analysis is not available"
+        default:
+            errorInfo["code"] = "UNKNOWN_ERROR"
+        }
+        
+        sendEvent("onTrackingFailed", errorInfo)
     }
 
     public func didCreate() {

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -55,7 +55,7 @@ export interface AsleepState {
   setIsTracking: (isTracking: boolean) => void;
   setIsTrackingPaused: (isTrackingPaused: boolean) => void;
   setDidClose: (didClose: boolean) => void;
-  setanalysisResult: (result: AsleepAnalysisResult | null) => void;
+  setAnalysisResult: (result: AsleepAnalysisResult | null) => void;
   setIsAnalyzing: (isAnalyzing: boolean) => void;
   setTrackingStartTime: (time: Date | null) => void;
   setIsInitialized: (initialized: boolean) => void;
@@ -307,11 +307,17 @@ export const useAsleepStore = create<AsleepState>()(
         const result = await AsleepModule.requestAnalysis();
         const convertedResult = convertKeysToCamelCase(result);
 
-        if (Platform.OS === "android") {
-          set({ analysisResult: convertedResult });
+        // Platform differences:
+        // Android: Returns the actual analysis result immediately and also sends onAnalysisResult event
+        // iOS: Returns acknowledgment data only, actual result comes through onAnalysisResult event
+        if (Platform.OS === "android" && convertedResult.sleepStages) {
+          // Android returns the actual session data
+          set({ analysisResult: convertedResult, isAnalyzing: false });
         }
+        // For iOS, isAnalyzing will be set to false when onAnalysisResult event fires
+        
         addLog(
-          `[requestAnalysis] Success - ${JSON.stringify(convertedResult)}`
+          `[requestAnalysis] Request sent - ${JSON.stringify(convertedResult)}`
         );
 
         return convertedResult;
@@ -345,7 +351,7 @@ export const useAsleepStore = create<AsleepState>()(
     setIsTracking: (isTracking) => set({ isTracking }),
     setIsTrackingPaused: (isTrackingPaused) => set({ isTrackingPaused }),
     setDidClose: (didClose) => set({ didClose }),
-    setanalysisResult: (result) => set({ analysisResult: result }),
+    setAnalysisResult: (result) => set({ analysisResult: result }),
     setIsAnalyzing: (isAnalyzing) => set({ isAnalyzing }),
     setTrackingStartTime: (time) => set({ trackingStartTime: time }),
     setIsInitialized: (initialized) => set({ isInitialized: initialized }),
@@ -392,7 +398,7 @@ export const initializeAsleepListeners = () => {
     setIsTrackingPaused,
     setError,
     setDidClose,
-    setanalysisResult,
+    setAnalysisResult,
     setIsAnalyzing,
     setIsSetupInProgress,
     setIsSetupComplete,
@@ -482,8 +488,8 @@ export const initializeAsleepListeners = () => {
       addLog(`[onSetupInProgress] progress: ${data.progress}%`);
     },
     onAnalysisResult: (data: any) => {
-      setanalysisResult(data);
-      setIsAnalyzing(true);
+      setAnalysisResult(data);
+      setIsAnalyzing(false);  // Analysis is complete, so set to false
       addLog(`[onAnalysisResult] ${JSON.stringify(data)}`);
     },
   };

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -256,7 +256,32 @@ export const useAsleepStore = create<AsleepState>()(
         const convertedReport = convertKeysToCamelCase(report);
 
         addLog("[getReport] Success");
-        return convertedReport;
+        
+        // Ensure the report has the expected AsleepReport structure
+        // Handle cases where native modules might return data in different formats
+        if (convertedReport && !convertedReport.session && convertedReport.sessionId) {
+          // If the data comes in a flat format (like AsleepSession), convert it to AsleepReport format
+          const normalizedReport: AsleepReport = {
+            timezone: convertedReport.timezone || "",
+            session: {
+              id: convertedReport.sessionId || convertedReport.id || sessionId,
+              createdTimezone: convertedReport.createdTimezone || "",
+              startTime: convertedReport.sessionStartTime || convertedReport.startTime || "",
+              endTime: convertedReport.sessionEndTime || convertedReport.endTime,
+              unexpectedEndTime: convertedReport.unexpectedEndTime,
+              state: convertedReport.state || "",
+              sleepStages: convertedReport.sleepStages,
+              breathStages: convertedReport.breathStages,
+              snoringStages: convertedReport.snoringStages,
+            },
+            missingDataRatio: convertedReport.missingDataRatio || 0,
+            peculiarities: convertedReport.peculiarities || [],
+            stat: convertedReport.stat,
+          };
+          return normalizedReport;
+        }
+        
+        return convertedReport as AsleepReport;
       } catch (error: any) {
         console.error("getReport error:", error);
         set({ error: error.message });


### PR DESCRIPTION
## Summary
- Update AsleepSDK dependency from 3.1.3 to 3.1.4
- Add support for new iOS SDK v3.1.4 error handling
- Fix state management issues
- Normalize report data structure for cross-platform consistency

## Changes
- **Updated SDK Version**: AsleepSDK 3.1.3 → 3.1.4 in `ios/Asleep.podspec`
- **Enhanced Error Handling**: Added specific error codes for new v3.1.4 error cases:
  - `ODA_INTEGRITY_FAIL`: Detects when ODA model files are corrupted or need updating
  - `NETWORK_OFFLINE`: Handles network connectivity issues
- **Bug Fixes**:
  - Fixed typo: `setanalysisResult` → `setAnalysisResult` 
  - Fixed `isAnalyzing` state management to properly reflect analysis completion
  - Normalized report data structure in `getReport` method to handle different formats from native modules
- **iOS Compatibility**: Updated example app to handle iOS-specific analysis result flow
- **Cross-Platform Consistency**: Ensure report data has consistent structure across Android and iOS

## Test Plan
- [x] Updated example app dependencies (`pod update AsleepSDK`)
- [ ] Test ODA error handling with corrupted model files
- [ ] Test network offline error handling
- [ ] Verify analysis result flow on iOS devices
- [ ] Test report data normalization with both flat and nested formats
- [ ] Ensure backward compatibility with existing implementations

🤖 Generated with [Claude Code](https://claude.ai/code)