### PR TITLE
Fix cross-platform error handling and add allowBluetoothA2DP option

### DIFF
--- a/android/src/main/java/ai/asleep/reactnative/AsleepModule.kt
+++ b/android/src/main/java/ai/asleep/reactnative/AsleepModule.kt
@@ -206,9 +206,10 @@ class AsleepModule : Module() {
                     override fun onFail(errorCode: Int, detail: String) {
                         isTracking = false
                         sendEvent("onDebugLog", mapOf("message" to "Sleep tracking failed: $errorCode - $detail"))
+                        val code = if (errorCode == 23499) "UPLOAD_TRACKING_TERMINATED" else "TRACKING_FAILED"
                         sendEvent("onTrackingFailed", mapOf(
                             "error" to detail,
-                            "code" to "TRACKING_FAILED",
+                            "code" to code,
                             "message" to detail,
                             "errorCode" to errorCode
                         ))
@@ -300,10 +301,12 @@ class AsleepModule : Module() {
                     notificationIcon = notificationIcon,
                     asleepTrackingListener = object : Asleep.AsleepTrackingListener {
                         override fun onFail(errorCode: Int, detail: String) {
+                            isTracking = false
                             sendEvent("onDebugLog", mapOf("message" to "Sleep tracking failed: $errorCode - $detail"))
+                            val code = if (errorCode == 23499) "UPLOAD_TRACKING_TERMINATED" else "TRACKING_FAILED"
                             sendEvent("onTrackingFailed", mapOf(
                                 "error" to detail,
-                                "code" to "TRACKING_FAILED",
+                                "code" to code,
                                 "message" to detail,
                                 "errorCode" to errorCode
                             ))
@@ -344,7 +347,7 @@ class AsleepModule : Module() {
         AsyncFunction("stopTracking") { promise: Promise ->
             Asleep.endSleepTracking()
             isTracking = false
-            promise.resolve("Tracking stopped")
+            promise.resolve(null)
         }
 
         AsyncFunction("getReport") { sessionId: String, promise: Promise ->
@@ -391,6 +394,7 @@ class AsleepModule : Module() {
                     override fun onFail(errorCode: Int, detail: String) {
                         val errorMessage = "Get report list failed: errorCode=$errorCode, detail=$detail"
                         sendEvent("onDebugLog", mapOf("message" to errorMessage))
+                        promise.reject("GET_REPORT_LIST_FAILED", errorMessage, null)
                     }
                 })
             } catch (e: Exception) {

--- a/ios/AsleepModule.swift
+++ b/ios/AsleepModule.swift
@@ -73,6 +73,8 @@ public class AsleepModule: Module {
                         additionalOptions.insert(.allowAirPlay)
                     case "allowBluetooth":
                         additionalOptions.insert(.allowBluetooth)
+                    case "allowBluetoothA2DP":
+                        additionalOptions.insert(.allowBluetoothA2DP)
                     default:
                         sendEvent("onDebugLog", ["message": "Unknown audio session option: \(name)"])
                     }

--- a/src/Asleep.types.ts
+++ b/src/Asleep.types.ts
@@ -162,7 +162,8 @@ export type AsleepAnalysisResult = {
 export type AudioSessionOption =
   | 'duckOthers'
   | 'allowAirPlay'
-  | 'allowBluetooth';
+  | 'allowBluetooth'
+  | 'allowBluetoothA2DP';
 
 export type TrackingConfig = {
   android?: {

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -395,16 +395,16 @@ export const useAsleepStore = create<AsleepState>()(
         const { addLog } = get();
         addLog("[stopTracking] Start");
 
-        const sessionId = await AsleepModule.stopTracking();
+        const result = await AsleepModule.stopTracking();
         set({
           didClose: true,
-          sessionId,
+          ...(result ? { sessionId: result } : {}),
           isTracking: false,
           isAnalyzing: false,
           trackingStartTime: null,
         });
 
-        addLog(`[stopTracking] Success - sessionId: ${sessionId}`);
+        addLog(`[stopTracking] Success - result: ${result}`);
       } catch (error: any) {
         console.error("stopTracking error:", error);
         set({ error: error.message });
@@ -757,6 +757,7 @@ export const initializeAsleepListeners = () => {
     // Connected: iOS didResume, Android NOT IMPLEMENTED
     onTrackingResumed: () => {
       setIsTrackingPaused(false);
+      setError(null);
       addLog(`[onTrackingResumed]`);
     },
     // Connected: iOS micPermissionWasDenied, Android NOT IMPLEMENTED


### PR DESCRIPTION
## Summary
- Add `allowBluetoothA2DP` to `AudioSessionOption` type and iOS Swift switch
- Map Android errorCode 23499 to `UPLOAD_TRACKING_TERMINATED` in both `connectSleepTracking` and `beginSleepTracking` onFail (cross-platform parity with iOS)
- Set `isTracking = false` in `beginSleepTracking` onFail (was missing, inconsistent with `connectSleepTracking`)
- Add `promise.reject()` to `getReportList` onFail (was leaving JS promise hanging indefinitely)
- Return `null` from Android `stopTracking` instead of string literal `"Tracking stopped"`; guard `AsleepStore` to only set `sessionId` from truthy return
- Clear error state on `onTrackingResumed` for transient errors

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (12/12)
- [ ] Test Android mid-session `onTrackingFailed` fires correctly for both fresh and reconnected sessions
- [ ] Test Android `getReportList` failure rejects properly
- [ ] Test `stopTracking` does not set sessionId to garbage string
- [ ] Verify `UPLOAD_TRACKING_TERMINATED` code emitted on both platforms for errorCode 23499

🤖 Generated with [Claude Code](https://claude.com/claude-code)