### PR TITLE
Document bare React Native installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,63 @@ expo install react-native-asleep
 
 ### For Bare React Native Projects
 
-1. Install the package:
+This library uses the Expo Modules API. Bare RN projects need Expo modules installed once; after that, autolinking handles the rest — no `react-native.config.js` or manual native linking.
 
-```bash
-npm install react-native-asleep zustand
+1. **Install Expo modules** (skip if already installed):
+
+   ```bash
+   npx install-expo-modules@latest
+   ```
+
+   It prompts `Install the Expo CLI integration? (Y/n)` — either answer wires the bare modules. See the [Expo bare guide](https://docs.expo.dev/bare/installing-expo-modules/) for details.
+
+2. **Install the package** (`npm install` / `pnpm add` / `yarn add`):
+
+   ```bash
+   npm install react-native-asleep zustand
+   ```
+
+3. **iOS**: in `ios/`, run `bundle install` (once) then `bundle exec pod install`. The project's `Gemfile` avoids host Ruby/CocoaPods conflicts. **Android**: no extra step.
+
+For permissions, see [Permissions](#2-permissions) below.
+
+#### Static framework note
+
+The iOS podspec sets `s.static_framework = true`. **Do not add `use_frameworks!` to your `Podfile`.** If your project already requires it, pin to static linkage:
+
+```ruby
+use_frameworks! :linkage => :static
 ```
 
-2. For iOS, run:
+`:linkage => :dynamic` is known to break Expo SDK 55 builds (see [expo/expo#44487](https://github.com/expo/expo/issues/44487), [#41556](https://github.com/expo/expo/issues/41556)).
 
-```bash
-npx pod-install
+#### Monorepo / workspace projects
+
+If `react-native-asleep` is hoisted to a parent `node_modules`, configure autolinking in your app's `package.json`:
+
+```json
+{
+  "expo": {
+    "autolinking": {
+      "nativeModulesDir": ".."
+    }
+  }
+}
 ```
 
-3. Ensure you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/).
+#### Reference configuration
+
+The [example app](./example) is the reference setup. Adjacent versions are expected to work but aren't verified.
+
+| Component                   | Version  |
+| --------------------------- | -------- |
+| React Native                | 0.79.2   |
+| Expo                        | 53       |
+| React                       | 19.0.0   |
+| iOS deployment target       | 14.0     |
+| Android `minSdkVersion`     | 24       |
+| Android `compileSdkVersion` | 34       |
+| Android `targetSdkVersion`  | 34       |
 
 ## Setup
 
@@ -53,9 +97,9 @@ npx pod-install
 
 ### 2. Permissions
 
-Add the following permissions to your app:
+#### iOS — declared by your app
 
-#### iOS
+Add the microphone usage description and audio background mode.
 
 **For Expo Managed Projects (app.json):**
 
@@ -83,15 +127,22 @@ Add the following permissions to your app:
 </array>
 ```
 
-#### Android (android/app/src/main/AndroidManifest.xml)
+#### Android — declared by the library
+
+The library declares its own permissions; the manifest merger combines them into your app. No `<uses-permission>` entries are needed in your `AndroidManifest.xml`. For reference, the library declares:
 
 ```xml
+<uses-permission android:name="android.permission.INTERNET" />
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
 <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+<uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 ```
+
+`RECORD_AUDIO` and `POST_NOTIFICATIONS` are runtime permissions — your app must request them via `PermissionsAndroid` (or equivalent) before starting tracking.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
     "react-native": "*",
     "zustand": "^5.0.1"
   },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
+  },
   "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary

- Replaces the 3-line bare RN install stub in [README.md](README.md) with a self-contained guide covering the `install-expo-modules` prerequisite, library install, iOS `bundle exec pod install` pattern, and a no-op Android step.
- Adds explicit guidance on `use_frameworks!` (do not use; if required, pin to `:linkage => :static`), monorepo autolinking, and a reference configuration table sourced from the example app.
- Reframes the Permissions section: the Android `<uses-permission>` block is declared in the library manifest and merged automatically — the previous README asked users to redeclare them.
- Adds `peerDependenciesMeta.expo.optional: true` in `package.json` so bare RN consumers no longer get a `missing required peer expo` warning. `npx install-expo-modules@latest` installs `expo` into the consumer project, so from the library's perspective it is genuinely optional.

The library code, native modules, and `expo-module.config.json` are unchanged — bare RN was always technically supported. This PR formalizes the support: documentation + correct peer signaling.

Closes [#48](https://github.com/asleep-ai/asleep-sdk-react-native/issues/48).

## Validation

Fresh-scaffold smoke test executed end-to-end:

1. `npx @react-native-community/cli@latest init SmokeBare --version 0.79.2` — clean RN 0.79.2 / React 19.0.0 project
2. `npx install-expo-modules@latest` — wired `Podfile`, `MainApplication.kt`, `babel.config.js`, `package.json`
3. `npm install <packed-tarball> zustand` — **0 peer warnings** (confirms `peerDependenciesMeta` working)
4. `bundle exec pod install` — **75 pods integrated**:
   - `Asleep (1.0.0)` wrapper resolved from `../node_modules/react-native-asleep/ios` via Expo autolinking
   - `AsleepSDK (3.2.0)` pulled in transitively
   - ExpoModulesCore + Hermes + RN core all integrated cleanly
   - No `use_frameworks!` conflict on a fresh scaffold

Android `assembleDebug` was not run in this validation pass (local disk constraint), and is not load-bearing here because the PR touches zero Android code/config — the existing downstream consumer (`asleep-ai/sleepstar`) exercises that path in production.

## Test plan

- [x] `pnpm lint` / `format:check` / `typecheck` / `test` pass locally
- [x] iOS smoke: fresh `npx @react-native-community/cli init` → `install-expo-modules` → `npm install <tarball>` → `bundle exec pod install` integrates Asleep + AsleepSDK without warnings
- [x] `npm pack` tarball includes `expo-module.config.json`, `ios/Asleep.podspec`, `android/build.gradle`, and `peerDependenciesMeta`
- [ ] (Reviewer, optional) `cd android && ./gradlew assembleDebug` in a bare RN smoke project

## Follow-up (out of scope, worth filing)

- `ios/Asleep.podspec` carries placeholder metadata (`s.version = '1.0.0'` vs package 1.0.15, `s.summary`, `s.author`, `s.homepage` point at Expo docs). Cosmetic but visible in `Podfile.lock`.
- iOS deployment target: podspec declares 14.0; Asleep's iOS docs say 15.0+. Worth confirming the runtime floor and aligning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)