### PR TITLE
fix(deps): bump android SDK to 3.2.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ gh workflow run release.yml -f version_type=patch
 1. **Native Modules** (`ios/AsleepModule.swift`, `android/.../AsleepModule.kt`)
    - Platform-specific implementations wrapping native Asleep SDKs
    - Handle audio recording, permission management, and sleep tracking
-   - iOS SDK version: 3.2.0, Android SDK version: 3.2.0
+   - iOS SDK version: 3.2.0, Android SDK version: 3.2.1
 
 2. **State Management** (`src/AsleepStore.ts`)
    - Zustand store with singleton pattern for consistent state across app

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 }
 
 dependencies {
-  implementation('ai.asleep:asleepsdk:3.2.0') {
+  implementation('ai.asleep:asleepsdk:3.2.1') {
     exclude group: 'com.android.support'
   }
 


### PR DESCRIPTION
## Summary

Bump bundled Android Asleep SDK from `3.2.0` to `3.2.1`. iOS stays at `3.2.0` (upstream latest — no `3.2.1` tag in `asleep-sdk-ios-src`).

## Upstream changes (`asleep-sdk-android-src` @ `v3.2.1`, 2026-04-08)

Commits:
- `3e4eed2` `fix: SecurityException 발생 시 서비스 재시작 방지 및 NetworkOnMainThreadException 수정`
- `6bc19c0` `chore: 버전 3.2.1(30201)`

### What actually changed

**1. Foreground service restart loop on `SecurityException`** (`AsleepService.kt`)

Old code silently swallowed `SecurityException` from `startForeground`, called `stopSelf()`, but then continued to run `continueTracking()` and `saveFgsAlive(true)` — leaving the SDK in an inconsistent state while Android's default `START_STICKY` kept retrying.

New code makes `startForegroundWithNotification` return `Boolean` and short-circuits to `START_NOT_STICKY` on failure, so Android does not restart the service and state stays consistent.

**2. `NetworkOnMainThreadException` from log uploader** (`AsleepService.kt`, `LogUploader.kt`)

`LogUploader.uploadLog()` performs network I/O. It was being called from the main thread at two sites — the size-threshold path in `LogUploader` and inside the `SecurityException` handler in `AsleepService`. Both are now wrapped in `Thread { ... }.start()`.

### Why this matters for RN consumers

Both bugs trigger on Android 12+ when foreground service start restrictions kick in mid-tracking — exactly the overnight background-tracking path this SDK exists for. Without the fix, consumers can hit an FGS restart loop and a hard crash from the log uploader on the very code path designed to report the failure.

Classified as `fix(deps)` per `AGENTS.md` versioning policy → RN patch release.

## Test plan
- [ ] Example app builds against Android SDK 3.2.1
- [ ] Cold-start tracking flow still green on Android
- [ ] No regressions during background tracking through device sleep