### PR TITLE
fix(release): use squash merge to match repo settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,9 @@ jobs:
             --body "Automated release PR for v$VERSION." \
             || true
 
+          # `--squash` matches repo settings (merge commits are disabled).
           gh pr merge "$BRANCH" \
-            --merge \
+            --squash \
             --delete-branch \
             --subject "chore(release): v$VERSION"
 


### PR DESCRIPTION
## Summary

v1.0.16 release dispatch failed at the `merge` job with:

```
GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
```

The repository setting only allows squash/rebase merges. The workflow was using `gh pr merge --merge`.

## Fix

`--merge` -> `--squash`. Squash also matches the desired release-history shape (one commit per release on main).

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch `gh workflow run release.yml -f version_type=patch`.
- [ ] Confirm the `Merge release PR to main` job now succeeds and downstream `publish-npm` + `release-github` complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)