### PR TITLE
fix(release): upgrade npm CLI before publish for OIDC handshake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,16 @@ jobs:
 
       - run: pnpm build
 
+      # npm CLI 11.5.1+ is required for the OIDC token exchange that backs
+      # Trusted Publishers. Node 22 ships with npm 10, which only signs the
+      # provenance attestation but does not exchange the GitHub OIDC token
+      # for an npm publish credential — leaving the actual PUT unauthenticated
+      # (npm returns 404 in that case, not 401, to avoid leaking package
+      # existence). Upgrading the CLI here keeps the rest of the toolchain
+      # on Node 22 while enabling tokenless publish.
+      - name: Upgrade npm CLI for OIDC publish
+        run: npm install -g npm@latest
+
       - name: Publish with provenance
         run: npm publish --provenance --access public
 


### PR DESCRIPTION
## Summary

v1.0.16 release dispatch failed at `publish-npm` with `404 Not Found - PUT https://registry.npmjs.org/react-native-asleep`. Investigation showed:

- npm Trusted Publishers IS configured on the package (carried over from semantic-release era).
- Provenance signing via `id-token: write` succeeded (Sigstore entry logged).
- But the actual publish PUT was unauthenticated because npm CLI 10 (shipped with Node 22) does not exchange GitHub OIDC tokens for npm publish credentials. That OIDC token exchange requires npm CLI >= 11.5.1.
- npm intentionally returns 404 (not 401) on unauthenticated PUT to avoid leaking package existence ([npm/cli#9088](https://github.com/npm/cli/issues/9088)).

## Fix

Add a single step in `publish-npm` that upgrades npm to the latest before the publish call. Keeps the rest of the toolchain on Node 22.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger `gh workflow run release.yml -f version_type=patch`.
- [ ] Confirm `publish-npm` succeeds and `react-native-asleep@1.0.17` lands on npm with provenance attestation.

## Cleanup notes

The orphan `v1.0.16` GitHub release and tag were already deleted, so the next dispatch will produce `v1.0.17` with AI bilingual notes spanning `v1.0.15..HEAD` (the same scope the v1.0.16 attempt covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)