### PR TITLE
feat!: v2 — fact-based state model, structured AsleepError, useAsleep + Asleep surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,16 +50,17 @@ gh workflow run release.yml -f version_type=patch
    - Handle audio recording, permission management, and sleep tracking
    - iOS SDK version: 3.2.0, Android SDK version: 3.2.1
 
-2. **State Management** (`src/AsleepStore.ts`)
-   - Zustand store with singleton pattern for consistent state across app
-   - Handles all SDK state including tracking status, session management, and error handling
-   - Provides event listener initialization and cleanup
+2. **State Model** (`src/AsleepStore.ts` + `src/store/createStore.ts`)
+   - Singleton vanilla store built on `useSyncExternalStore`; no external state-library dependency
+   - Stores native facts (`setupStatus`, `trackingStatus`, identifiers, analysis, and one structured error)
+   - Funnels every native event through a pure transition and one store write
+   - Owns the ref-counted native-listener lifecycle
 
-3. **API Surface** (`src/index.ts`) — currently 4 parallel surfaces, being consolidated in v2.0 (see #47):
-   - `useAsleep` hook — primary surface for React components (the only one consumers actually use; see Library Boundary Principles below)
-   - `AsleepSDK` singleton — dead code in practice, slated for removal
-   - default `asleep` class instance — has bugs (bypasses zustand store), slated for removal
-   - `asleepStore` raw zustand — leaks implementation detail, slated for removal
+3. **API Surface** (`src/index.ts`) — v2.0 lean surface:
+   - `useAsleep` — primary React hook; returns the public state projection plus bound actions
+   - `Asleep` — thin imperative escape hatch with `initialize`, `getState`, `subscribe`, and `addEventListener`
+   - `AsleepError` — named value export; data/config/event models are named type exports
+   - No default export, public store, mutable setters, or parallel SDK namespace
 
 4. **Type Definitions** (`src/Asleep.types.ts`)
    - TypeScript interfaces for all API responses and configurations
@@ -97,8 +98,8 @@ This is a **primitive SDK library**, not a sleep-tracking framework. Apps build 
 
 - Native module bridge (iOS Swift / Android Kotlin → JS)
 - SDK lifecycle: `setup`, `initAsleepConfig`, `startTracking`, `stopTracking`, `resumeTracking`, `checkAndRestoreTracking`
-- State synchronization between native and JS (via internal zustand store)
-- Raw data exposure: `sessionId`, `analysisResult`, `AsleepReport`, `AsleepSession`, `AsleepAverageReport`
+- State synchronization between native and JS (via the internal vanilla store and event reducer)
+- Raw data exposure: `sessionId`, `analysisResult`, `AsleepReport`, `AsleepSession`, `AsleepAverageReport`, `AsleepError`
 - Permission *methods* (check + request as separate operations)
 - Background lifecycle plumbing (Android foreground service, iOS background audio mode)
 - Stable hook API (`useAsleep`) + a thin escape hatch for non-React contexts
@@ -115,46 +116,72 @@ This is a **primitive SDK library**, not a sleep-tracking framework. Apps build 
 - Analytics / observability — emit events the consumer hooks into, do not log directly
 - Application state (tracking start time as wall-clock, user preferences, feature flags)
 
-### Anti-patterns currently in the codebase (to fix in v2.0)
+### v2.0 boundary decisions
 
-1. **UI calls from the library** — `Alert.alert("Microphone permission denied")` in `src/index.ts:56`. The library must not invoke `Alert`, `Modal`, or any UI surface. Throw a typed error and let the app render its own UX.
-2. **Redundant `console.error` alongside `throw`** — many catch blocks log via `console.error` and re-throw the same error (~9 occurrences in `src/AsleepStore.ts`). The throw already surfaces the error; the duplicate log clutters consumer output and bypasses observability systems like Sentry. Strip the log, keep the throw. (Note: `console.warn` for deprecations and `__DEV__`-gated warnings are fine — that matches React/RN convention.)
-3. **Auto-request permissions inside `startTracking`** — `startTracking` silently calls `requestRequiredPermissions`. This causes "spooky" permission dialogs from the consumer's perspective. Split into `hasRequiredPermissions()` (check) and `requestRequiredPermissions()` (request); `startTracking` assumes permission and throws if missing. *(Status: Android `beginSleepTracking` now rejects with `PERMISSION_REQUIRED` instead of calling `ActivityCompat.requestPermissions`. iOS `beginSleepTracking` in `ios/AsleepModule.swift` still needs the same treatment.)*
-4. **Parallel API surfaces with state divergence** — the `Asleep` class default export calls `AsleepModule` directly and skips the zustand store, so `useAsleep().isTracking` does not update when `asleep.startTracking()` is called. See #47.
-5. **`addEventListener` only on the class, not in hook output or namespace** — forces consumers into `ref` hacks or store-internal access.
-6. **Wall-clock state and getter exposed publicly** — `trackingStartTime` is stored in the zustand store and `getTrackingDurationMinutes()` is exposed as a public method (`src/AsleepStore.ts:31` and `src/AsleepStore.ts:613`). The actual consumer (sleepstar) maintains its own start-time and computes duration with finer-grained timers, so these public surfaces are unused. Keep `trackingStartTime` internal for restore logic; consider removing the public `getTrackingDurationMinutes` API in v2.0.
+- The library is headless: no `Alert`, modal, permission-denied screen, or other UI primitive.
+- `startTracking` checks permission without requesting it. Consumers explicitly call `requestRequiredPermissions()` from a user-driven flow.
+- `useAsleep` and `Asleep` read the same memoized public projection; no parallel direct-native API may bypass the store.
+- `AsleepError` is the single error object. Classification lives on `error.category` / `error.sdkCode` / `error.caseName`.
+- Native events and SDK actions are the sole state writers. Public setters and the raw store are not exported.
+- `trackingStartTime` is internal restore state. Apps own wall-clock duration and product timers.
+- The package has no external state-library dependency.
 
 ### Real-world consumer pattern (validation)
 
 [`asleep-ai/sleepstar`](https://github.com/asleep-ai/sleepstar) is the primary consumer. Audit (May 2026) of 11 source files outside `node_modules` and worktrees:
 
 - 100% of SDK access goes through `useAsleep()` hook
-- 0 uses of `AsleepSDK`, default `asleep` export, `asleepStore`, or `addEventListener`
+- 0 uses of the removed `AsleepSDK`, default `asleep` export, or raw store
 - Types (`AsleepReport`, `AsleepSession`, `AsleepAverageReport`) are imported as named exports
 
-sleepstar wraps `useAsleep` in app-level hooks (`useTracking`, `useAstIdManager`, `useReport`, `useSessionMetrics`) and adds: app-level zustand store (`useTrackingStore`), Amplify cloud sync, LiveActivity/Widget/Alarm coordination, sleep-stage UI calculations, and permission UX. **All of that is correct application architecture and must not migrate into the library.**
+sleepstar wraps `useAsleep` in app-level hooks (`useTracking`, `useAstIdManager`, `useReport`, `useSessionMetrics`) and adds app-owned state, cloud sync, LiveActivity/Widget/Alarm coordination, sleep-stage UI calculations, and permission UX. **All of that is correct application architecture and must not migrate into the library.**
 
 This evidence is why v2.0 (#47) collapses to **`useAsleep` + thin escape hatch + types**, not a full `AsleepSDK` mirror.
 
 ## Development Guidelines
 
 ### State Management Pattern
-- Always use store actions for state updates
-- Check `isSetupInProgress` and `isTracking` flags to prevent duplicate operations
-- Handle platform differences in analysis result handling
 
-### Error Handling
-- All async operations should be wrapped in try-catch blocks
-- Errors are automatically stored in the state and accessible via the `error` property
-- Use the `addLog` function for debug logging when `enableLog(true)` is set
-- **Error-code `Set`s that write state must be mutually exclusive or explicitly clear each other's flags.** `onTrackingFailed` dispatches on several `Set`s (`TERMINAL_`, `RECORDING_DEAD_`, `RECOVERY_REQUIRED_`) and zustand `setState` merges partials, so a flag raised by one bucket survives a later error handled by another unless that branch clears it. Add a regression test for every escalation path a real device can produce
-- **`errorInfo` must stay in lockstep with `error`.** Every write or clear of `error` pairs an `errorInfo` write in the same `setState` — the classified object in `onTrackingFailed`, `null` everywhere else (action catches, success clears, `setError`). A stale `category` surviving a later unrelated error would misclassify it. Exception: the `startTracking`/`stopTracking` catches keep an `errorInfo` that was published during the same call (snapshot reference comparison) instead of nulling it — Android fires the classified `onTrackingFailed` event before rejecting the same lifecycle promise, and the raw rejection message must not clobber that verdict. Stale verdicts from earlier failures are still cleared, so guard failures surface their own message
+These eight rules are the v2 state-model review checklist:
+
+1. **Native is the source of truth.** The JS store is a projection. Hydrate initial tracking state from `AsleepModule.isTracking()` and keep cold-start restore in `checkAndRestoreTracking()`.
+2. **One writer per fact.** State fields have an explicit owner: native event reducer, action result, or restore path. Do not add public setters or competing promise/event writers.
+3. **Illegal states are unrepresentable.** Store `SetupStatus` and `TrackingStatus`; derive public booleans in the shared projection instead of storing overlapping flags.
+4. **One notification per native event.** Every handler computes one partial through `applyEvent` and performs one `setState`. If debug logging is enabled, fold the log line into that same partial.
+5. **Errors are one object.** Store one `AsleepError` carrying `code`, `category`, `sdkCode`, `caseName`, and `cause`; never create a parallel classification field.
+6. **Every await seam is guarded.** Snapshot `error` before a native call. A success may clear only that snapshot; a failure must preserve and throw a classified event error that arrived during the await.
+7. **Derived data is not stored.** `trackingStartTime` stays internal for restore logic; apps own wall-clock duration.
+8. **Import is side-effect-free.** Attach native listeners only through the ref-counted initializer used by `useAsleep` and `Asleep.initialize()`.
+
+Additional state rules:
+
+- `toPublicState(internal)` is the only projection used by both public surfaces and must memoize by internal-state reference.
+- `onAnalysisResult` is the only writer of `analysisResult`; normalize Android snake_case before storing.
+- Keep failure buckets mutually exclusive and ordered: recording-dead string codes, recovery-required string codes, terminal string/numeric codes, transient numeric codes, then unknown.
+- Add a regression test for every real-device escalation path and assert notification counts for every event with logging both disabled and enabled.
+
+### Error Handling & Signals
+
+The library selects a mechanism by signal type:
+
+| Signal type | Mechanism | Example |
+|---|---|---|
+| Runtime failure | Normalize and throw `AsleepError`; store the same instance when applicable | Native bridge rejection |
+| Precondition violation | Throw `AsleepError` with `MISSING_PREREQUISITE`, `INVALID_STATE`, `OPERATION_IN_PROGRESS`, `PERMISSION_DENIED`, or `BATTERY_NOT_EXEMPTED` | `startTracking` before required checks |
+| Unsupported platform | Throw `AsleepError("UNSUPPORTED_PLATFORM", ...)` | `resumeTracking()` on Android |
+| Native failure event | Normalize payload once and write it through the event reducer | `onTrackingFailed`, `onSetupDidFail`, `onUserJoinFailed` |
+| Deprecation/developer education | `[Asleep]`-prefixed `console.warn`, guarded by `typeof __DEV__ !== "undefined" && __DEV__` | Deprecated no-op |
+| Operational log | Fold `addLog(message)` into the current event partial when `enableLog(true)` | Tracking lifecycle trace |
+
+- Every action and query throws `AsleepError` on failure; do not return `null` or `[]` as an error sentinel.
+- `normalizeError` must preserve native `sdkCode` and `caseName`, retain the original value as `cause`, and never stringify an error into its message.
+- `startTracking` and `stopTracking` must throw the classified error instance published during the same native call instead of replacing it with the promise rejection.
+- Success paths use the snapshot guard; they never clear an error written while awaiting the native result.
 - **`console.*` discipline** (matches RN library convention — React, Reanimated, React Navigation, etc. all follow this):
   - Do NOT pair `console.error` with `throw` of the same error — the throw alone surfaces it; the duplicate log clutters consumer output
   - Do NOT use `console.error` as the only error handling — throw or emit so consumers can react
   - Do NOT use `console.log` in normal operation flow — use the opt-in `addLog` action when `enableLog(true)`
-  - OK to use `console.warn` for one-shot deprecation notices (`[lib] X is deprecated, use Y`)
-  - OK to use `__DEV__`-gated warnings for developer education (lint-like checks)
+  - Every warning is `[Asleep]`-prefixed and guarded by `typeof __DEV__ !== "undefined" && __DEV__`
 - **Do not call `Alert.alert` or any UI primitive** — the library is headless; the consumer renders UX
 
 ### Testing Changes
@@ -177,7 +204,7 @@ RN SDK semver tracks the bundled native SDK changes so consumers can read the ve
 | Native patch (e.g. 3.2.0 → 3.2.1) | `fix(deps): bump <ios\|android> SDK to X.Y.Z` | patch |
 | Native minor (e.g. 3.2.x → 3.3.0) | `feat(deps): bump <ios\|android> SDK to X.Y.Z` | minor |
 | Native major (e.g. 3.x → 4.0.0) | `feat(deps)!: bump <ios\|android> SDK to X.0.0` + `BREAKING CHANGE:` footer | major |
-| JS feature (new public API on `useAsleep`/`AsleepSDK`) | `feat: ...` | minor |
+| JS feature (new public API on `useAsleep`/`Asleep`) | `feat: ...` | minor |
 | JS bug fix | `fix: ...` | patch |
 | Docs / CI / internal chores | `chore: ...` | no release |
 
@@ -199,14 +226,14 @@ The wrapper smooths over a few native quirks so JS sees a consistent event model
 |---|---|---|
 | `failedTerminally` flag in both `AsleepTrackingListener` instances suppresses `onTrackingClosed` after `onFail`, gated on the 13-code `TERMINAL_TRACKING_ERROR_CODES` companion set | `android/src/main/java/ai/asleep/reactnative/AsleepModule.kt` (`createTrackingListener`, shared by `connectSleepTracking` and `beginSleepTracking`) | Android SDK 3.2.x `AsleepCore.onErrorCodeReceived` (`AsleepCore.kt:413-467`) fires both `onFail` and `onFinish` and tears the session down for exactly 13 fatal codes. Without the guard JS receives `onTrackingFailed` followed by `onTrackingClosed` for one fatal error; without the terminal-set gate a non-terminal `onFail` (e.g. 23000 upload-retry exhaustion, where the session survives) would suppress a later genuine `onFinish` and flip the module's internal `isTracking` while native tracking continues |
 | `.interruptionRecoveryFailed` case in `didFail` switch maps to `INTERRUPTION_RECOVERY_FAILED` | `ios/AsleepModule.swift` `didFail(error:)` | iOS SDK 3.2.0 added `AsleepError.interruptionRecoveryFailed(attemptsCount:)`. Without the explicit case it falls into `default:` and JS only sees `UNKNOWN_ERROR` for a recoverable-with-foreground scenario |
-| `.audioInitializationFailed` maps to `AUDIO_INITIALIZATION_FAILED`, and `RECORDING_DEAD_ERROR_CODES` clears recording state without setting `didClose` | `ios/AsleepModule.swift` `didFail(error:)`; `src/AsleepStore.ts` | iOS SDK 3.2.0 `Asleep.SleepTrackingManager+Delegate.swift:31-38` stops tracking with `shouldCloseSession: false`; `TrackingOrchestrator.swift:431-436` stops the recorder and returns before closing the session. Recording is dead, but the native session remains open and must be stopped before starting again |
-| `.cannotActivateInBackground` maps to `CANNOT_ACTIVATE_IN_BACKGROUND`, and `RECOVERY_REQUIRED_ERROR_CODES` sets `isRecoveryRequired` | `ios/AsleepModule.swift` `didFail(error:)`; `src/AsleepStore.ts` | iOS SDK 3.2.0 `RecordingService+EngineLifecycle.swift:133-145` reports the error when the engine cannot start; `RecordingService+State.swift:175-190` emits resume before attempting the engine restart. The consumer must use `isRecoveryRequired` and call `resumeTracking()` in foreground; only a later upload proves recovery |
-| `TERMINAL_TRACKING_ERROR_CODES` set in `onTrackingFailed` handler clears `isTracking`/`isAnalyzing`/`didClose`/`trackingStartTime` | `src/AsleepStore.ts` | iOS 3.2.1 `closeSessionSilently()` on 403/429 (and `interruptionRecoveryFailed` after 3 retries) tears the session down internally without firing `didClose`. JS state would otherwise stay `isTracking: true` forever, blocking subsequent `startTracking()` calls via the duplicate-call guard |
-| `onTrackingResumed` clears error unconditionally but gates the paused-state mutation on `isTrackingPaused` | `src/AsleepStore.ts` | iOS 3.2.1 `RecordingService` fires `interruptedSender.send(false)` from both `handleRecovering()` and `handleResumed()`, producing two `didResume` events per recovery cycle. Some iOS recovery paths (e.g. `cannotActivateInBackground` retry) also reach this handler without a preceding `didInterrupt`, so error clearing must happen unconditionally while only the dedup-sensitive paused-state write stays gated |
-| `onAnalysisResult` runs `convertKeysToCamelCase(data)` before writing to the store | `src/AsleepStore.ts` `initializeAsleepListeners` | Android SDK 3.2.x serializes session payloads with snake_case keys (`sleep_stages`, `sleep_start_time`, etc.) when bridging through Expo modules. iOS emits camelCase. Without normalization, consumers reading `analysisResult` from the store get mixed casing across platforms and the documented `AsleepAnalysisResult` type only matches iOS |
+| `.audioInitializationFailed` maps to `AUDIO_INITIALIZATION_FAILED`, and the recording-dead event transition sets `trackingStatus: "idle"` without setting `didClose` | `ios/AsleepModule.swift` `didFail(error:)`; `src/AsleepStore.ts` tracking-failure reducer | iOS SDK 3.2.0 `Asleep.SleepTrackingManager+Delegate.swift:31-38` stops tracking with `shouldCloseSession: false`; `TrackingOrchestrator.swift:431-436` stops the recorder and returns before closing the session. Recording is dead, but the native session remains open and must be stopped before starting again |
+| `.cannotActivateInBackground` maps to `CANNOT_ACTIVATE_IN_BACKGROUND`, and the recovery-required transition sets `trackingStatus: "recoveryRequired"` | `ios/AsleepModule.swift` `didFail(error:)`; `src/AsleepStore.ts` tracking-failure reducer | iOS SDK 3.2.0 `RecordingService+EngineLifecycle.swift:133-145` reports the error when the engine cannot start; `RecordingService+State.swift:175-190` emits resume before attempting the engine restart. The consumer must use `isRecoveryRequired` and call `resumeTracking()` in foreground; only a later upload proves recovery |
+| Terminal string and numeric error buckets set `trackingStatus: "idle"`, clear analysis/start-time facts, and set `didClose` | `src/AsleepStore.ts` tracking-failure reducer | iOS 3.2.1 `closeSessionSilently()` on 403/429 (and `interruptionRecoveryFailed` after 3 retries) tears the session down internally without firing `didClose`. JS state would otherwise remain tracking forever, blocking subsequent `startTracking()` calls via the duplicate-call guard |
+| `onTrackingResumed` clears error unconditionally but changes status only when `trackingStatus === "paused"` | `src/AsleepStore.ts` event reducer | iOS 3.2.1 `RecordingService` fires `interruptedSender.send(false)` from both `handleRecovering()` and `handleResumed()`, producing two `didResume` events per recovery cycle. Some iOS recovery paths (e.g. `cannotActivateInBackground` retry) also reach this handler without a preceding `didInterrupt`, so error clearing must happen unconditionally while only the dedup-sensitive paused-state write stays gated |
+| `onAnalysisResult` runs `convertKeysToCamelCase(data)` before writing to the store | `src/AsleepStore.ts` event reducer | Android SDK 3.2.x serializes session payloads with snake_case keys (`sleep_stages`, `sleep_start_time`, etc.) when bridging through Expo modules. iOS emits camelCase. Without normalization, consumers reading `analysisResult` from the store get mixed casing across platforms and the documented `AsleepAnalysisResult` type only matches iOS |
 | `requestAnalysis` action does NOT write `analysisResult`/`isAnalyzing` from the resolved promise | `src/AsleepStore.ts` `requestAnalysis` | Android SDK 3.2.x `AsleepModule.requestAnalysis()` resolves the promise with the full session payload AND fires `onAnalysisResult` immediately after; iOS resolves with an ack only and the event carries the real payload. Writing state from the promise branch double-updates the store on Android. The event handler is the single owner |
 | `sdkCode` field on iOS error payloads carries `error.errorCode.code`; legacy `errorCode` stays the NSError bridging value | `ios/AsleepModule.swift` `didFail` / `setupDidFail` / `didFailUserJoin` | iOS SDK 3.2.0 `AsleepError` does not conform to `CustomNSError`, so `(error as NSError).code` is the Swift enum declaration ordinal, not a documented Asleep code. The documented numeric code (10000-34999) is only reachable via the `errorCode` computed property (`Asleep.Interface.swift:473-572`, the doc-comment-recommended v3.2.0+ API). The ordinal `errorCode` field is kept because existing consumers match ordinals (e.g. 38/39) |
-| `TERMINAL_TRACKING_SDK_CODES` (13 numeric codes) joins the terminal bucket, `TRANSIENT_TRACKING_SDK_CODES` (23000, 23500) classifies as transient, and the verdict is published as `errorInfo.category` | `src/AsleepStore.ts` `onTrackingFailed` | Android maps 12 of its 13 session-terminal codes to the generic `TRACKING_FAILED` string (only 23499 gets `UPLOAD_TRACKING_TERMINATED`), so string-only matching left `isTracking` stuck true for e.g. 11003 ERR_AUDIO. Numeric classification from `AsleepCore.kt:413-467` (terminal set) and `AsleepErrorCode.kt` (23000 ERR_UPLOAD_FAILED / 23500 ERR_UPLOAD_SERVER_ERROR are absent from it — the session survives) restores the distinction and exposes it to consumers as data instead of forcing per-app code lists. The numeric set is a FALLBACK: explicit iOS string buckets (recordingDead/recoveryRequired) win first, because iOS reuses 11003 (`.audioInitializationFailed` → `.audio`, `Asleep.Interface.swift:482-483`) for a recorder-dead-but-session-open failure while the same number is session-terminal on Android. Keep the set shared across platforms — iOS start/stop failures arriving as `UNKNOWN_ERROR` + 22xxx/24xxx rely on it to clear optimistic `isTracking` |
+| `TERMINAL_TRACKING_SDK_CODES` (13 numeric codes) joins the terminal bucket, `TRANSIENT_TRACKING_SDK_CODES` (23000, 23500) classifies as transient, and the verdict is published as `error.category` | `src/AsleepStore.ts` tracking-failure reducer | Android maps 12 of its 13 session-terminal codes to the generic `TRACKING_FAILED` string (only 23499 gets `UPLOAD_TRACKING_TERMINATED`), so string-only matching left tracking state stuck for e.g. 11003 ERR_AUDIO. Numeric classification from `AsleepCore.kt:413-467` (terminal set) and `AsleepErrorCode.kt` (23000 ERR_UPLOAD_FAILED / 23500 ERR_UPLOAD_SERVER_ERROR are absent from it — the session survives) restores the distinction and exposes it to consumers as data instead of forcing per-app code lists. The numeric set is a FALLBACK: explicit iOS string buckets (recordingDead/recoveryRequired) win first, because iOS reuses 11003 (`.audioInitializationFailed` → `.audio`, `Asleep.Interface.swift:482-483`) for a recorder-dead-but-session-open failure while the same number is session-terminal on Android. Keep the set shared across platforms — iOS start/stop failures arriving as `UNKNOWN_ERROR` + 22xxx/24xxx rely on it to clear optimistic tracking state |
 
 When adding a new compensation:
 1. Cite the upstream SDK file/line and the version it shipped in.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ v2 deliberately removes the parallel and mutable v1 surfaces:
 
 1. `error: string | null` is now `AsleepError | null`. Render `error?.message` and branch on `error?.code`.
 2. `errorInfo` is removed. Read `error.category`, `error.sdkCode`, and `error.caseName`.
-3. Report and analysis queries throw `AsleepError` on failure instead of returning `null` or `[]`.
+3. Report and analysis queries throw `AsleepError` on failure instead of returning `null` or `[]`. A session that has no report surfaces as code `REPORT_NOT_FOUND`; an empty report list still resolves to `[]`.
 4. Public state setters are removed. Native events and SDK actions are the sole state writers; `clearError()` remains public.
 5. `getTrackingDurationMinutes()` is removed and `trackingStartTime` is internal. Apps own wall-clock duration.
 6. `requestMicrophonePermission()` is removed. Use `requestRequiredPermissions()`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Advanced sleep tracking SDK for React Native applications, powered by Asleep's A
 
 ## Status
 
-This SDK is under active development. The API may evolve between minor versions until v2.0 — pin to exact versions and review the [CHANGELOG](./CHANGELOG.md) before upgrading.
+This SDK is under active development. v2 has a deliberately small public surface; pin to exact versions and review the [CHANGELOG](./CHANGELOG.md) before upgrading.
 
 ## Overview
 
@@ -33,10 +33,8 @@ This library uses the Expo Modules API. Bare RN projects need Expo modules insta
 2. **Install the package** (`npm install` / `pnpm add` / `yarn add`):
 
    ```bash
-   npm install react-native-asleep zustand
+   npm install react-native-asleep
    ```
-
-   `zustand` is a peer dependency through v1.x and will be removed in v2.0.
 
 3. **iOS**: in `ios/`, run `bundle install` (once) then `bundle exec pod install`. The project's `Gemfile` avoids host Ruby/CocoaPods conflicts. **Android**: no extra step.
 
@@ -77,6 +75,13 @@ The [example app](./example) is the reference setup. Adjacent versions are expec
 | Android `minSdkVersion`     | 24       |
 | Android `compileSdkVersion` | 34       |
 | Android `targetSdkVersion`  | 34       |
+
+#### Bundled native SDK versions
+
+| Platform | Native SDK version |
+|---|---|
+| iOS | 3.2.0 |
+| Android | 3.2.1 |
 
 ## Setup
 
@@ -139,17 +144,18 @@ The library declares its own permissions; the manifest merger combines them into
 
 ```tsx
 import { useEffect } from "react";
-import { Button, View } from "react-native";
-import { useAsleep } from "react-native-asleep";
+import { Button, Text, View } from "react-native";
+import { AsleepError, useAsleep } from "react-native-asleep";
 
 function SleepTracker() {
   const {
+    status,
     isTracking,
-    sessionId,
     error,
     initAsleepConfig,
     checkAndRestoreTracking,
     checkBatteryOptimization,
+    hasRequiredPermissions,
     requestRequiredPermissions,
     startTracking,
     stopTracking,
@@ -165,14 +171,25 @@ function SleepTracker() {
   }, []);
 
   const handleStart = async () => {
-    await requestRequiredPermissions();
-    await startTracking({
-      android: { notification: { title: "Sleep tracking", text: "Recording..." } },
-    });
+    try {
+      if (!(await hasRequiredPermissions())) {
+        const granted = await requestRequiredPermissions();
+        if (!granted) return;
+      }
+
+      await startTracking({
+        android: { notification: { title: "Sleep tracking", text: "Recording..." } },
+      });
+    } catch (cause) {
+      if (!(cause instanceof AsleepError)) throw cause;
+      // `error` is also updated reactively and rendered below.
+    }
   };
 
   return (
     <View>
+      <Text>Status: {status}</Text>
+      {error ? <Text>{error.message}</Text> : null}
       <Button title={isTracking ? "Stop" : "Start"} onPress={isTracking ? stopTracking : handleStart} />
     </View>
   );
@@ -183,13 +200,78 @@ For ODA (On-Device Analysis) mode, call `setup()` instead of `initAsleepConfig()
 
 ## API surface
 
-The library exports a single React hook plus types:
+The v2 API has one reactive hook, one thin imperative escape hatch, and named value/type exports:
 
 ```ts
-import { useAsleep, type AsleepReport, type AsleepSession, type AsleepAverageReport } from "react-native-asleep";
+import {
+  Asleep,
+  AsleepError,
+  useAsleep,
+  type AsleepAverageReport,
+  type AsleepReport,
+  type AsleepSession,
+  type TrackingStatus,
+} from "react-native-asleep";
 ```
 
-`useAsleep()` returns reactive state (`isTracking`, `sessionId`, `error`, `analysisResult`, ...) and bound actions (`startTracking`, `stopTracking`, `getReport`, `getReportList`, `requestAnalysis`, ...). Hover the return type in your editor for the full surface; the type definitions in [`src/Asleep.types.ts`](./src/Asleep.types.ts) are the source of truth and stay in sync with the native modules.
+`useAsleep()` attaches the native listeners while mounted and returns the public state plus bound actions.
+
+### Public state
+
+The store keeps native facts internally and derives the public booleans from `status`:
+
+| Field | Meaning |
+|---|---|
+| `status` | `"idle"`, `"tracking"`, `"paused"`, or `"recoveryRequired"` |
+| `isTracking` | `true` for every status except `"idle"`; recovery-required sessions are still live |
+| `isTrackingPaused` | `true` only while `status` is `"paused"` |
+| `isRecoveryRequired` | `true` only while `status` is `"recoveryRequired"` |
+| `isSetupInProgress` / `isSetupComplete` | Derived setup lifecycle |
+| `sessionId` / `userId` | Current native identifiers |
+| `error` | Last `AsleepError`, or `null` |
+| `analysisResult` / `isAnalyzing` | Latest analysis event and request state |
+| `didClose` / `isODAEnabled` / `log` | Session history, mode, and opt-in debug log |
+
+`trackingStartTime`, listener bookkeeping, and mutable setters are internal implementation details.
+
+### Actions
+
+The hook exposes:
+
+- Setup and restore: `setup`, `initAsleepConfig`, `checkAndRestoreTracking`
+- Tracking: `startTracking`, `stopTracking`, `resumeTracking`
+- Reports: `getReport`, `getReportList`, `getAverageReport`, `deleteSession`, `requestAnalysis`
+- Prerequisites: `checkBatteryOptimization`, `requestBatteryOptimizationExemption`, `hasRequiredPermissions`, `requestRequiredPermissions`
+- Utilities: `enableLog`, `clearError`, `addEventListener`, and the deprecated no-op `setCustomNotification`
+
+`requestAnalysis()` returns the Android analysis result or the iOS `{ status: "requested", timestamp }` acknowledgement. On both platforms, `onAnalysisResult` is the only writer of reactive `analysisResult`.
+
+### Non-React contexts
+
+Use `Asleep` for background callbacks and other code where hooks are unavailable:
+
+```ts
+import { Asleep } from "react-native-asleep";
+
+// Required when no mounted useAsleep() hook owns the native listener lifecycle.
+const teardown = Asleep.initialize();
+
+const unsubscribe = Asleep.subscribe(({ status, error }) => {
+  console.log(status, error?.code);
+});
+
+const offAnalysis = Asleep.addEventListener("onAnalysisResult", (result) => {
+  console.log(result);
+});
+
+await Asleep.getState().stopTracking();
+
+offAnalysis();
+unsubscribe();
+teardown();
+```
+
+`initialize()` is ref-counted, so it is safe to use alongside mounted hooks. Importing the package alone does not attach native listeners.
 
 On iOS, `isRecoveryRequired` becomes `true` when recording cannot resume while the app is in the background. After the app returns to the foreground, call `resumeTracking()`. The flag clears only after the next successful audio upload. `resumeTracking()` is iOS-only and rejects with `UNSUPPORTED_PLATFORM` on Android.
 
@@ -206,7 +288,19 @@ See [AGENTS.md](./AGENTS.md#native-behavior-compensations) for the full table in
 
 ## Error classification
 
-`useAsleep().errorInfo` is a structured view of the last tracking failure. Its `category` field is the library's objective verdict on recoverability; the app decides what severity to log at:
+Every failed action and native failure event produces an `AsleepError`, which extends `Error`:
+
+```ts
+class AsleepError extends Error {
+  readonly code: string;
+  readonly category?: "terminal" | "recordingDead" | "recoveryRequired" | "transient" | "unknown";
+  readonly sdkCode?: number;
+  readonly caseName?: string;
+  readonly cause?: unknown;
+}
+```
+
+Branch on the stable `code`, render `message`, and forward the error itself to observability tooling. Tracking failures also carry the library's objective recovery classification in `category`; the app decides what severity to record:
 
 | `category` | Meaning | Suggested app-side severity |
 |---|---|---|
@@ -217,29 +311,51 @@ See [AGENTS.md](./AGENTS.md#native-behavior-compensations) for the full table in
 | `unknown` | Unclassified code — do not assume it is benign. | error |
 
 ```ts
-const { errorInfo } = useAsleep();
+const { error } = useAsleep();
 
 useEffect(() => {
-  if (!errorInfo) return;
-  if (errorInfo.category === "recoveryRequired" || errorInfo.category === "transient") {
-    analytics.track("asleep_recoverable_error", errorInfo); // visibility without paging
+  if (!error) return;
+  if (error.category === "recoveryRequired" || error.category === "transient") {
+    analytics.track("asleep_recoverable_error", {
+      code: error.code,
+      sdkCode: error.sdkCode,
+      category: error.category,
+    });
   } else {
-    Sentry.captureException(new Error(`[Asleep] ${errorInfo.code}`), { extra: errorInfo });
+    Sentry.captureException(error);
   }
-}, [errorInfo]);
+}, [error]);
 ```
 
-`errorInfo.sdkCode` carries the numeric error code documented by the native Asleep SDKs (both platforms). The legacy `errorCode` event-payload field is deprecated: on iOS it holds a Swift enum ordinal from NSError bridging, not the documented code.
+`sdkCode` is the numeric code documented by the native Asleep SDKs. The legacy `errorCode` event-payload field remains for wire compatibility but is deprecated: on iOS it is a Swift enum ordinal from NSError bridging, not the documented code.
+
+All actions, including report queries, throw `AsleepError` on failure. Queries no longer return `null` or `[]` as failure sentinels. Successful actions clear only the error that was present when the native call began; a classified failure event arriving during the await is preserved.
 
 ## Best practices
 
-- **Permission flow**: call `requestRequiredPermissions()` *before* `startTracking()`. As of v1.0.18 the Android native module rejects `startTracking` with `PERMISSION_REQUIRED` when `RECORD_AUDIO` / `FOREGROUND_SERVICE_MICROPHONE` aren't granted.
+- **Permission flow**: use `hasRequiredPermissions()` for a non-interactive check, then call `requestRequiredPermissions()` from a user-initiated flow. `startTracking()` never opens a permission dialog and throws `PERMISSION_DENIED` when permission is missing.
 - **Battery optimization (Android, required)**: long sessions get killed without an exemption. Call `checkBatteryOptimization()` before `startTracking()`; if not exempted, call `requestBatteryOptimizationExemption()` and follow the system prompt. iOS's no-op call keeps cross-platform code uniform.
-- **Error handling**: gate log severity on `useAsleep().errorInfo?.category` (see [Error classification](#error-classification)) and switch on `errorInfo.code` for category-specific UI rather than parsing `message` substrings.
+- **Error handling**: gate log severity on `useAsleep().error?.category` and switch on `error.code` for category-specific UI rather than parsing message text.
+- **Non-React lifecycle**: pair every `Asleep.initialize()` with its returned teardown function.
+
+## Migrating from 1.x
+
+v2 deliberately removes the parallel and mutable v1 surfaces:
+
+1. `error: string | null` is now `AsleepError | null`. Render `error?.message` and branch on `error?.code`.
+2. `errorInfo` is removed. Read `error.category`, `error.sdkCode`, and `error.caseName`.
+3. Report and analysis queries throw `AsleepError` on failure instead of returning `null` or `[]`.
+4. Public state setters are removed. Native events and SDK actions are the sole state writers; `clearError()` remains public.
+5. `getTrackingDurationMinutes()` is removed and `trackingStartTime` is internal. Apps own wall-clock duration.
+6. `requestMicrophonePermission()` is removed. Use `requestRequiredPermissions()`.
+7. `startTracking()` no longer requests permission. Check with `hasRequiredPermissions()`, explicitly request if needed, then start.
+8. The default export, `Asleep` class, `AsleepSDK`, and raw `asleepStore` export are removed. Use `useAsleep()` or the named `Asleep` escape hatch.
+9. `zustand` is no longer a dependency. Remove it from your app if nothing else uses it.
+10. Use the additive `status: TrackingStatus` field when a single lifecycle value is clearer than multiple derived booleans.
 
 ## Troubleshooting
 
-- **`PERMISSION_REQUIRED` from `startTracking`**: call `requestRequiredPermissions()` first, then retry.
+- **`PERMISSION_DENIED` from `startTracking`**: check and request microphone permission from a user-initiated flow, then retry.
 - **`MISSING_PREREQUISITE` from `startTracking`**: call `checkAndRestoreTracking()` and `checkBatteryOptimization()` before `startTracking()`.
 - **Tracking ends unexpectedly on Android**: battery optimization is on; call `checkBatteryOptimization()` and follow the prompt.
 - **Network errors**: verify API key and connectivity.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ v2 deliberately removes the parallel and mutable v1 surfaces:
 8. The default export, `Asleep` class, `AsleepSDK`, and raw `asleepStore` export are removed. Use `useAsleep()` or the named `Asleep` escape hatch.
 9. `zustand` is no longer a dependency. Remove it from your app if nothing else uses it.
 10. Use the additive `status: TrackingStatus` field when a single lifecycle value is clearer than multiple derived booleans.
+11. Android 13+: `requestRequiredPermissions()` still requests `POST_NOTIFICATIONS` (so the foreground-service notification stays visible), but its return value now reflects only what tracking needs to run — microphone-side permissions, matching `hasRequiredPermissions()`. In 1.x a denied notification permission made it return `false` even though tracking could start.
 
 ## Troubleshooting
 

--- a/android/src/main/java/ai/asleep/reactnative/AsleepModule.kt
+++ b/android/src/main/java/ai/asleep/reactnative/AsleepModule.kt
@@ -282,16 +282,7 @@ class AsleepModule : Module() {
         
         AsyncFunction("startTracking") { config: Map<String, Any>?, promise: Promise ->
             try {
-                val audioPermission = ContextCompat.checkSelfPermission(appContext.reactContext!!, Manifest.permission.RECORD_AUDIO)
-                // FOREGROUND_SERVICE_MICROPHONE was introduced in API 34 (UPSIDE_DOWN_CAKE).
-                // Gating on TIRAMISU (API 33) would false-deny on Android 13 where the permission
-                // doesn't exist yet.
-                val fgsPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    ContextCompat.checkSelfPermission(appContext.reactContext!!, Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
-                } else {
-                    PackageManager.PERMISSION_GRANTED
-                }
-                if (audioPermission != PackageManager.PERMISSION_GRANTED || fgsPermission != PackageManager.PERMISSION_GRANTED) {
+                if (!hasRequiredPermissions()) {
                     // beginSleepTracking would crash with SecurityException at
                     // startForeground(type=microphone) on API 34+. Reject so JS requests via
                     // requestRequiredPermissions() and retries.
@@ -464,6 +455,10 @@ class AsleepModule : Module() {
                 sendEvent("onDebugLog", mapOf("message" to errorMessage))
                 promise.reject("UNEXPECTED_ERROR", errorMessage, e)
             }
+        }
+
+        AsyncFunction("hasRequiredPermissions") { promise: Promise ->
+            promise.resolve(hasRequiredPermissions())
         }
 
         // Deprecated method for backward compatibility
@@ -657,6 +652,21 @@ class AsleepModule : Module() {
     private inline fun <I, reified O> I.convert(): O {
         val json = gson.toJson(this)
         return gson.fromJson(json, object : TypeToken<O>() {}.type)
+    }
+
+    private fun hasRequiredPermissions(): Boolean {
+        val context = appContext.reactContext!!
+        val audioPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
+        // FOREGROUND_SERVICE_MICROPHONE was introduced in API 34 (UPSIDE_DOWN_CAKE).
+        // Gating on TIRAMISU (API 33) would false-deny on Android 13 where the permission
+        // doesn't exist yet.
+        val fgsPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
+        } else {
+            PackageManager.PERMISSION_GRANTED
+        }
+        return audioPermission == PackageManager.PERMISSION_GRANTED &&
+            fgsPermission == PackageManager.PERMISSION_GRANTED
     }
 
     private suspend fun requestMicrophonePermission(): Boolean = suspendCancellableCoroutine { cont ->

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -13,7 +13,7 @@ import {
   Platform,
 } from "react-native";
 import { useTracking } from "./useTracking";
-import { useAsleep, AsleepSleptSession, AsleepNeverSleptSession } from "react-native-asleep/src";
+import { useAsleep, type AsleepSleptSession, type AsleepNeverSleptSession } from "react-native-asleep";
 
 const SHOW_DEBUG_LOG = true;
 
@@ -43,8 +43,8 @@ const App = () => {
     requestAnalysis,
     enableLog,
     isTrackingPaused,
-    getTrackingDurationMinutes,
-    isInitialized,
+    trackingStartTime,
+    isSetupComplete,
   } = useTracking();
 
   const { didClose, deleteSession } = useAsleep();
@@ -59,7 +59,7 @@ const App = () => {
   // error
   useEffect(() => {
     if (error) {
-      addLog(`Error: ${error}`);
+      addLog(`Error: ${error.message}`);
     }
   }, [error]);
 
@@ -73,22 +73,23 @@ const App = () => {
 
   useEffect(() => {
     let interval: NodeJS.Timeout;
-    if (isTracking && !isTrackingPaused) {
-      interval = setInterval(async () => {
-        try {
-          const duration = await getTrackingDurationMinutes();
-          setTrackingDuration(duration);
-        } catch (error) {
-          console.error("Failed to get tracking duration:", error);
-        }
+    if (isTracking && !isTrackingPaused && trackingStartTime) {
+      const updateDuration = () => {
+        setTrackingDuration((Date.now() - trackingStartTime) / (60 * 1000));
+      };
+      updateDuration();
+      interval = setInterval(() => {
+        updateDuration();
       }, 1000);
+    } else if (!isTracking) {
+      setTrackingDuration(0);
     }
     return () => {
       if (interval) {
         clearInterval(interval);
       }
     };
-  }, [isTracking, isTrackingPaused, getTrackingDurationMinutes]);
+  }, [isTracking, isTrackingPaused, trackingStartTime]);
 
   const addLog = (message: string) => {
     console.log("message", message);
@@ -208,7 +209,7 @@ const App = () => {
         addLog(`Request analysis response: ${JSON.stringify(result)}`);
 
         // For Android, show the result immediately
-        if (Platform.OS === 'android' && result.sleepStages) {
+        if (Platform.OS === 'android' && !("status" in result) && result.sleepStages) {
           showModal("Analysis Result", result);
         } else if (Platform.OS === 'ios') {
           // For iOS, show the current analysisResult if available
@@ -556,7 +557,7 @@ const App = () => {
         <View>
           <Text>User ID: {userId}</Text>
           <Text>Session ID: {sessionId}</Text>
-          <Text>SDK Initialized: {isInitialized ? "Yes" : "No"}</Text>
+          <Text>SDK Initialized: {isSetupComplete ? "Yes" : "No"}</Text>
           <Text>
             Tracking Status:{" "}
             {!isTracking
@@ -582,7 +583,7 @@ const App = () => {
               ,
             </Text>
           )}
-          {error && <Text style={styles.errorText}>Error: {error}</Text>}
+          {error && <Text style={styles.errorText}>Error: {error.message}</Text>}
         </View>
         <ScrollView style={styles.logContainer}>
           {logs.map((log, index) => (
@@ -595,7 +596,7 @@ const App = () => {
         <View style={styles.buttonContainer}>
           <Button
             title="Start Tracking"
-            disabled={!isInitialized || isTracking}
+            disabled={!isSetupComplete || isTracking}
             onPress={_startTracking}
           />
           <Button

--- a/example/useTracking.tsx
+++ b/example/useTracking.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { Alert } from "react-native";
-import { useAsleep, AsleepSession, AsleepSDK } from "../src";
+import { useAsleep, type AsleepSession } from "../src";
 import { create } from "zustand";
 
 // Zustand store interface
@@ -48,13 +48,14 @@ export const useTracking = () => {
     error,
     didClose,
     log,
-    isInitialized,
     enableLog,
     isODAEnabled,
     isAnalyzing,
     requestAnalysis,
+    requestRequiredPermissions,
+    checkBatteryOptimization,
+    requestBatteryOptimizationExemption,
     isTrackingPaused,
-    getTrackingDurationMinutes,
     isSetupInProgress,
     isSetupComplete,
   } = useAsleep();
@@ -74,11 +75,11 @@ export const useTracking = () => {
   // Initialize SDK
   useEffect(() => {
     enableLog(true);
-    console.log("🐤 isInitialized", isInitialized);
-    if (!isInitialized) {
+    console.log("🐤 isSetupComplete", isSetupComplete);
+    if (!isSetupComplete && !isSetupInProgress) {
       initSDK();
     }
-  }, [isInitialized]);
+  }, [isSetupComplete, isSetupInProgress]);
 
   // Manage start time when tracking state changes
   useEffect(() => {
@@ -111,6 +112,14 @@ export const useTracking = () => {
       }
 
       if (!isTracking) {
+        const permissionGranted = await requestRequiredPermissions();
+        if (!permissionGranted) {
+          Alert.alert(
+            "Microphone Permission Required",
+            "Grant microphone permission, then tap Start Tracking again."
+          );
+          return;
+        }
         await startTracking({ "android": { "notification": { "title": "Asleep Tracking", "text": "Look at the useTracking code to change!" } } });
         setTrackingStartTime(Date.now());
         console.log("🐤 Tracking started");
@@ -170,7 +179,7 @@ export const useTracking = () => {
       // IMPORTANT: Check battery optimization on BOTH platforms
       // This ensures iOS developers test battery optimization handling,
       // preventing issues for their Android users in production
-      const batteryStatus = await AsleepSDK.checkBatteryOptimization();
+      const batteryStatus = await checkBatteryOptimization();
       console.log(`🔋 Battery optimization check - Platform: ${batteryStatus.platform}, Exempted: ${batteryStatus.exempted}`);
 
       // Only prompt on Android when not exempted
@@ -184,7 +193,7 @@ export const useTracking = () => {
             {
               text: "Open Settings",
               onPress: async () => {
-                const result = await AsleepSDK.requestBatteryOptimizationExemption();
+                const result = await requestBatteryOptimizationExemption();
                 if (!result) {
                   console.log("🔋 Battery settings opened, user needs to disable optimization");
                 }
@@ -234,8 +243,8 @@ export const useTracking = () => {
   );
 
   const fetchReportList = useCallback(async () => {
-    console.log("fetchReportList, isInitialized", isInitialized);
-    if (!isInitialized) return;
+    console.log("fetchReportList, isSetupComplete", isSetupComplete);
+    if (!isSetupComplete) return;
 
     const today = new Date();
     const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -245,7 +254,7 @@ export const useTracking = () => {
 
     const reportList = await getReportListWrapper(fromDate, toDate);
     setReportList(reportList ?? []);
-  }, [isInitialized, getReportListWrapper]);
+  }, [isSetupComplete, getReportListWrapper]);
 
   const checkPermissionAndStartTracking = async () => {
     if (isSetupInProgress) {
@@ -266,7 +275,7 @@ export const useTracking = () => {
     startTracking: startTrackingWrapper,
     stopTracking: stopTrackingWrapper,
     initSDK,
-    isInitialized,
+    isSetupComplete,
     tryStopTracking,
     getReport,
     getReportList: getReportListWrapper,
@@ -289,9 +298,7 @@ export const useTracking = () => {
     requestAnalysis,
     enableLog,
     isTrackingPaused,
-    getTrackingDurationMinutes,
     isSetupInProgress,
-    isSetupComplete,
   };
 };
 

--- a/ios/AsleepModule.swift
+++ b/ios/AsleepModule.swift
@@ -167,6 +167,10 @@ public class AsleepModule: Module {
             return trackingManager?.getTrackingStatus().sessionId != nil
         }
 
+        AsyncFunction("hasRequiredPermissions") { () -> Bool in
+            return AVAudioSession.sharedInstance().recordPermission == .granted
+        }
+
         // Deprecated method for backward compatibility
         AsyncFunction("requestMicrophonePermission") { () -> Bool in
             let audioSession = AVAudioSession.sharedInstance()

--- a/package.json
+++ b/package.json
@@ -51,15 +51,13 @@
     "expo-module-scripts": "^5.0.8",
     "expo-modules-core": "^1.12.19",
     "oxfmt": "^0.51.0",
-    "oxlint": "^1.66.0",
-    "zustand": "^5.0.12"
+    "oxlint": "^1.66.0"
   },
   "peerDependencies": {
     "expo": "*",
     "expo-modules-core": ">=1.12.0",
     "react": ">=18.2.0",
-    "react-native": ">=0.74.0",
-    "zustand": ">=5.0.0"
+    "react-native": ">=0.74.0"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       oxlint:
         specifier: ^1.66.0
         version: 1.66.0
-      zustand:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/react@19.2.14)(react@19.0.0)
 
   example:
     dependencies:
@@ -11864,9 +11861,4 @@ snapshots:
   zustand@5.0.12(@types/react@19.0.14)(react@19.0.0):
     optionalDependencies:
       '@types/react': 19.0.14
-      react: 19.0.0
-
-  zustand@5.0.12(@types/react@19.2.14)(react@19.0.0):
-    optionalDependencies:
-      '@types/react': 19.2.14
       react: 19.0.0

--- a/src/Asleep.types.ts
+++ b/src/Asleep.types.ts
@@ -167,6 +167,10 @@ export type AsleepAnalysisAck = {
   timestamp: number;
 };
 
+export type SetupStatus = "idle" | "inProgress" | "complete";
+
+export type TrackingStatus = "idle" | "tracking" | "paused" | "recoveryRequired";
+
 export type AudioSessionOption = "duckOthers" | "allowAirPlay" | "allowBluetooth" | "allowBluetoothA2DP";
 
 export type TrackingConfig = {
@@ -195,23 +199,39 @@ export type TrackingConfig = {
 export type AsleepErrorCategory = "terminal" | "recordingDead" | "recoveryRequired" | "transient" | "unknown";
 
 /**
- * Structured view of the last onTrackingFailed event, exposed as
- * useAsleep().errorInfo alongside the legacy `error` JSON string. Cleared to
- * null wherever `error` is cleared.
+ * Structured error used everywhere the SDK reports a failure.
+ *
+ * `code` is a stable machine identifier. Classified tracking failures also
+ * carry their category and documented native SDK code, while `cause` retains
+ * the original rejection or event payload for observability.
  */
-export type AsleepErrorInfo = {
-  /** Stable string code from the native module (e.g. "UPLOAD_TRACKING_TERMINATED"). */
-  code: string;
-  category: AsleepErrorCategory;
-  /**
-   * Numeric code documented by the native Asleep SDKs (range 10000-34999):
-   * iOS `AsleepError.errorCode.code` (v3.2.0+), Android listener `errorCode`.
-   */
-  sdkCode?: number;
-  message?: string;
-  /** iOS: Swift enum case description for cases without an explicit code mapping. */
-  caseName?: string;
-};
+export class AsleepError extends Error {
+  readonly code: string;
+  readonly category?: AsleepErrorCategory;
+  readonly sdkCode?: number;
+  readonly caseName?: string;
+  readonly cause?: unknown;
+
+  constructor(
+    code: string,
+    message: string,
+    options?: {
+      cause?: unknown;
+      category?: AsleepErrorCategory;
+      sdkCode?: number;
+      caseName?: string;
+    },
+  ) {
+    super(message);
+    this.name = "AsleepError";
+    this.code = code;
+    this.category = options?.category;
+    this.sdkCode = options?.sdkCode;
+    this.caseName = options?.caseName;
+    this.cause = options?.cause;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 export type AsleepEventType = {
   onTrackingCreated: { sessionId?: string };

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -1,112 +1,62 @@
-import { create } from "zustand";
-import { subscribeWithSelector } from "zustand/middleware";
 import { EventEmitter } from "expo-modules-core";
-import { Platform, PermissionsAndroid } from "react-native";
-import {
+import { PermissionsAndroid, Platform } from "react-native";
+import type {
+  AsleepAnalysisAck,
+  AsleepAnalysisResult,
+  AsleepAverageReport,
   AsleepConfig,
-  AsleepSetupConfig,
   AsleepErrorCategory,
-  AsleepErrorInfo,
   AsleepEventType,
   AsleepReport,
   AsleepSession,
-  AsleepAverageReport,
-  AsleepAnalysisResult,
-  AsleepAnalysisAck,
+  AsleepSetupConfig,
+  SetupStatus,
   TrackingConfig,
+  TrackingStatus,
 } from "./Asleep.types";
+import { AsleepError } from "./Asleep.types";
 import AsleepModule from "./AsleepModule";
+import { createStore } from "./store/createStore";
 
 const emitter = new EventEmitter(AsleepModule);
 
-// All dev-only warnings below are gated with an inline
-// `typeof __DEV__ !== "undefined" && __DEV__` check rather than a helper
-// function. Metro's inline plugin substitutes the bare `__DEV__` identifier
-// for the literal at build time, then constant-folds `typeof <literal>` and
-// the `&&` so the entire branch is dead-code-eliminated in production
-// bundles. Wrapping the check in a function (e.g. `if (isDev())`) defeats
-// that DCE because Metro does not constant-fold through call expressions.
-// The `typeof` guard also keeps the module importable from plain Node,
-// custom bundlers, or unconfigured jest setups without a ReferenceError.
+// Native sessions are already gone for these errors and no close event follows.
+const TERMINAL_TRACKING_ERROR_CODES = new Set<string>(["UPLOAD_TRACKING_TERMINATED", "INTERRUPTION_RECOVERY_FAILED"]);
 
-// Error codes emitted on onTrackingFailed for which the native SDK has already
-// terminated the session and will not deliver onTrackingClosed. JS must clear
-// tracking state itself when one of these arrives. See AGENTS.md "Native Behavior
-// Compensations" for the upstream behavior these guard against.
-const TERMINAL_TRACKING_ERROR_CODES = new Set<string>([
-  "UPLOAD_TRACKING_TERMINATED", // iOS 403/429 closeSessionSilently; Android errorCode 23499
-  "INTERRUPTION_RECOVERY_FAILED", // iOS 3 failed auto-resume attempts (3.2.0+)
-]);
-
-// iOS SDK 3.2.0 stops the recorder without closing the native session when
-// audio engine initialization fails. The session must be stopped and restarted.
+// iOS 3.2.0 stops recording but leaves the native session open.
 const RECORDING_DEAD_ERROR_CODES = new Set<string>(["AUDIO_INITIALIZATION_FAILED"]);
 
-// iOS SDK 3.2.0 reports this when the audio engine cannot restart in the
-// background. The consumer must call resumeTracking() after returning foreground.
+// iOS 3.2.0 needs an explicit foreground resume after this failure.
 const RECOVERY_REQUIRED_ERROR_CODES = new Set<string>(["CANNOT_ACTIVATE_IN_BACKGROUND"]);
 
-// Numeric-code twin of TERMINAL_TRACKING_ERROR_CODES, matched against the
-// `sdkCode` payload field. Android SDK 3.2.x AsleepCore.onErrorCodeReceived
-// tears the session down and dual-fires onFail + onFinish for exactly these
-// codes (the native module suppresses the duplicate onFinish), so JS must
-// clear tracking state here or isTracking stays stuck true.
-// Must stay in sync with the Kotlin TERMINAL_TRACKING_ERROR_CODES companion
-// set in android/src/main/java/ai/asleep/reactnative/AsleepModule.kt.
+// Android SDK 3.2.x tears the session down for exactly these codes. Keep this
+// synchronized with AsleepModule.kt's TERMINAL_TRACKING_ERROR_CODES.
 const TERMINAL_TRACKING_SDK_CODES = new Set<number>([
-  11003, // ERR_AUDIO
-  22000,
-  22401,
-  22409,
-  22422,
-  22500, // ERR_CREATE_*
-  23499, // ERR_UPLOAD_TRACKING_TERMINATED
-  24000,
-  24400,
-  24401,
-  24403,
-  24404,
-  24500, // ERR_CLOSE_*
+  11003, 22000, 22401, 22409, 22422, 22500, 23499, 24000, 24400, 24401, 24403, 24404, 24500,
 ]);
 
-// Upload failures the native session survives: absent from the AsleepCore
-// terminal set above, so the Android SDK 3.2.x keeps the session open and later
-// uploads continue (UploadDataTask retries 5xx internally before reporting).
-// Deliberately small — only codes verifiable in upstream sources.
-const TRANSIENT_TRACKING_SDK_CODES = new Set<number>([
-  23000, // ERR_UPLOAD_FAILED
-  23500, // ERR_UPLOAD_SERVER_ERROR
-]);
+// The native session survives these exhausted upload attempts.
+const TRANSIENT_TRACKING_SDK_CODES = new Set<number>([23000, 23500]);
 
-export interface AsleepState {
-  didClose: boolean;
-  isTracking: boolean;
-  isTrackingPaused: boolean;
-  isRecoveryRequired: boolean;
-  error: string | null;
-  // Structured view of the last onTrackingFailed event. Kept in lockstep with
-  // `error`: every write or clear of `error` pairs an errorInfo write — a
-  // stale category surviving a later unrelated error would misclassify it.
-  errorInfo: AsleepErrorInfo | null;
-  userId: string | null;
+export interface InternalAsleepState {
+  setupStatus: SetupStatus;
+  trackingStatus: TrackingStatus;
   sessionId: string | null;
-  showDebugLog: boolean;
-  log: string;
+  userId: string | null;
+  error: AsleepError | null;
   analysisResult: AsleepAnalysisResult | null;
-  isODAEnabled: boolean;
   isAnalyzing: boolean;
+  didClose: boolean;
+  isODAEnabled: boolean;
   trackingStartTime: Date | null;
   isInitialized: boolean;
-  isSetupInProgress: boolean;
-  isSetupComplete: boolean;
-
-  // Service status tracking
   hasCheckedStatus: boolean;
-
-  // Battery optimization tracking
   hasCheckedBatteryOptimization: boolean;
+  showDebugLog: boolean;
+  log: string;
+}
 
-  // actions
+export interface AsleepActions {
   setup: (config: AsleepSetupConfig) => Promise<void>;
   initAsleepConfig: (config: AsleepConfig) => Promise<void>;
   checkAndRestoreTracking: () => Promise<{ hasActiveSession: boolean }>;
@@ -115,205 +65,270 @@ export interface AsleepState {
   startTracking: (config?: TrackingConfig) => Promise<void>;
   stopTracking: () => Promise<void>;
   resumeTracking: () => Promise<void>;
-  getReport: (sessionId: string) => Promise<AsleepReport | null>;
+  getReport: (sessionId: string) => Promise<AsleepReport>;
   getReportList: (fromDate: string, toDate: string) => Promise<AsleepSession[]>;
-  getAverageReport: (fromDate: string, toDate: string) => Promise<AsleepAverageReport | null>;
+  getAverageReport: (fromDate: string, toDate: string) => Promise<AsleepAverageReport>;
   deleteSession: (sessionId: string) => Promise<void>;
-  requestMicrophonePermission: () => Promise<boolean>; // deprecated
+  requestAnalysis: () => Promise<AsleepAnalysisResult | AsleepAnalysisAck>;
+  hasRequiredPermissions: () => Promise<boolean>;
   requestRequiredPermissions: () => Promise<boolean>;
   setCustomNotification: (title: string, text: string) => Promise<void>;
   enableLog: (print: boolean) => void;
   clearError: () => void;
-  requestAnalysis: () => Promise<AsleepAnalysisResult | AsleepAnalysisAck | null>;
   addEventListener: <K extends keyof AsleepEventType>(
     eventType: K,
     listener: (data: AsleepEventType[K]) => void,
   ) => () => void;
-  getTrackingDurationMinutes: () => number;
-
-  // internal actions
-  setError: (error: string | null) => void;
-  setUserId: (userId: string | null) => void;
-  setSessionId: (sessionId: string | null) => void;
-  setIsTracking: (isTracking: boolean) => void;
-  setIsTrackingPaused: (isTrackingPaused: boolean) => void;
-  setDidClose: (didClose: boolean) => void;
-  setAnalysisResult: (result: AsleepAnalysisResult | null) => void;
-  setIsAnalyzing: (isAnalyzing: boolean) => void;
-  setTrackingStartTime: (time: Date | null) => void;
-  setIsInitialized: (initialized: boolean) => void;
-  setIsSetupInProgress: (inProgress: boolean) => void;
-  setIsSetupComplete: (complete: boolean) => void;
-  setHasCheckedStatus: (checked: boolean) => void;
-  setHasCheckedBatteryOptimization: (checked: boolean) => void;
-  addLog: (log: string) => void;
 }
 
-const convertKeysToCamelCase = (obj: any): any => {
-  if (Array.isArray(obj)) {
-    return obj.map(convertKeysToCamelCase);
-  } else if (obj !== null && obj.constructor === Object) {
-    return Object.keys(obj).reduce((acc, key) => {
-      const camelKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
-      acc[camelKey] = convertKeysToCamelCase(obj[key]);
-      return acc;
+export interface AsleepPublicState {
+  status: TrackingStatus;
+  isTracking: boolean;
+  isTrackingPaused: boolean;
+  isRecoveryRequired: boolean;
+  isSetupInProgress: boolean;
+  isSetupComplete: boolean;
+  sessionId: string | null;
+  userId: string | null;
+  error: AsleepError | null;
+  analysisResult: AsleepAnalysisResult | null;
+  isAnalyzing: boolean;
+  didClose: boolean;
+  isODAEnabled: boolean;
+  log: string;
+}
+
+export type AsleepPublicApi = AsleepPublicState & AsleepActions;
+
+const initialTrackingStatus: TrackingStatus =
+  typeof AsleepModule.isTracking === "function" && AsleepModule.isTracking() ? "tracking" : "idle";
+
+export const useAsleepStore = createStore<InternalAsleepState>(() => ({
+  setupStatus: "idle",
+  trackingStatus: initialTrackingStatus,
+  sessionId: null,
+  userId: null,
+  error: null,
+  analysisResult: null,
+  isAnalyzing: false,
+  didClose: false,
+  isODAEnabled: false,
+  trackingStartTime: null,
+  isInitialized: false,
+  hasCheckedStatus: false,
+  hasCheckedBatteryOptimization: false,
+  showDebugLog: false,
+  log: "",
+}));
+
+const convertKeysToCamelCase = (value: any): any => {
+  if (Array.isArray(value)) return value.map(convertKeysToCamelCase);
+  if (value !== null && value.constructor === Object) {
+    return Object.keys(value).reduce((result, key) => {
+      const camelKey = key.replace(/_([a-z])/g, (_match, letter: string) => letter.toUpperCase());
+      result[camelKey] = convertKeysToCamelCase(value[key]);
+      return result;
     }, {} as any);
   }
-  return obj;
+  return value;
 };
 
-export const useAsleepStore = create<AsleepState>()(
-  subscribeWithSelector((set, get) => ({
-    // initial state
-    didClose: false,
-    isTracking: AsleepModule.isTracking ? AsleepModule.isTracking() : false,
-    isTrackingPaused: false,
-    isRecoveryRequired: false,
-    error: null,
-    errorInfo: null,
-    userId: null,
-    sessionId: null,
-    showDebugLog: false,
-    log: "",
-    analysisResult: null,
-    isODAEnabled: false,
-    isAnalyzing: false,
-    trackingStartTime: null,
-    isInitialized: false,
-    isSetupInProgress: false,
-    isSetupComplete: false,
+type ErrorOptions = {
+  category?: AsleepErrorCategory;
+  sdkCode?: number;
+  caseName?: string;
+};
 
-    // Service status state
-    hasCheckedStatus: false,
+export const normalizeError = (source: unknown, fallbackCode: string, options: ErrorOptions = {}): AsleepError => {
+  if (source instanceof AsleepError && Object.keys(options).length === 0) return source;
 
-    // Battery optimization state
-    hasCheckedBatteryOptimization: false,
+  const payload =
+    source && typeof source === "object"
+      ? (source as {
+          code?: unknown;
+          message?: unknown;
+          error?: unknown;
+          detail?: unknown;
+          sdkCode?: unknown;
+          caseName?: unknown;
+        })
+      : undefined;
+  const code = typeof payload?.code === "string" ? payload.code : fallbackCode;
+  const message =
+    typeof payload?.message === "string"
+      ? payload.message
+      : typeof payload?.error === "string"
+        ? payload.error
+        : typeof payload?.detail === "string"
+          ? payload.detail
+          : source instanceof Error
+            ? source.message
+            : String(source ?? "Unknown error");
 
-    // actions
-    setup: async (config: AsleepSetupConfig) => {
-      try {
-        const { addLog, isSetupInProgress, isTracking } = get();
+  return new AsleepError(code, message, {
+    cause: source instanceof AsleepError ? (source.cause ?? source) : source,
+    category: options.category ?? (source instanceof AsleepError ? source.category : undefined),
+    sdkCode:
+      options.sdkCode ??
+      (typeof payload?.sdkCode === "number"
+        ? payload.sdkCode
+        : source instanceof AsleepError
+          ? source.sdkCode
+          : undefined),
+    caseName:
+      options.caseName ??
+      (typeof payload?.caseName === "string"
+        ? payload.caseName
+        : source instanceof AsleepError
+          ? source.caseName
+          : undefined),
+  });
+};
 
-        // Prevent duplicate execution if setup is already in progress
-        if (isSetupInProgress) {
-          addLog("[setup] Setup is already in progress. Please try again later.");
-          throw new Error("Setup is already in progress.");
-        }
+const logPartial = (message: string, state = useAsleepStore.getState()): Partial<InternalAsleepState> => {
+  if (!state.showDebugLog) return {};
+  const now = new Date();
+  const time = `${now.getHours().toString().padStart(2, "0")}:${now
+    .getMinutes()
+    .toString()
+    .padStart(2, "0")}:${now.getSeconds().toString().padStart(2, "0")}`;
+  const log = `[${time}]${message}`;
+  console.log(`[Asleep]${log}`);
+  return { log };
+};
 
-        // Block setup execution if tracking is in progress
-        if (isTracking) {
-          addLog("[setup] Cannot execute setup while tracking is in progress.");
-          throw new Error("Cannot execute setup while tracking is in progress.");
-        }
+const addLog = (message: string) => {
+  useAsleepStore.setState(logPartial(message));
+};
 
-        addLog("[setup] Start");
-        set({ isSetupInProgress: true, error: null, errorInfo: null });
+const storeAndThrow = (error: AsleepError, partial: Partial<InternalAsleepState> = {}): never => {
+  useAsleepStore.setState({ ...partial, error });
+  throw error;
+};
 
-        await AsleepModule.setup(config.apiKey, config.baseUrl, config.callbackUrl, config.service, config.enableODA);
+const guardedFailure = (
+  source: unknown,
+  fallbackCode: string,
+  errorBefore: AsleepError | null,
+  partial: Partial<InternalAsleepState> = {},
+): never => {
+  const current = useAsleepStore.getState().error;
+  if (current !== null && current !== errorBefore) {
+    useAsleepStore.setState(partial);
+    throw current;
+  }
+  return storeAndThrow(normalizeError(source, fallbackCode), partial);
+};
 
-        // Store ODA enabled state. Clearing `error` on success keeps the
-        // reactive `useAsleep().error` field aligned with the actual SDK status
-        // (no stale failure messages after a successful retry).
-        set({
-          isODAEnabled: config.enableODA || false,
-          isInitialized: true,
-          isSetupInProgress: false,
-          isSetupComplete: true,
-          error: null,
-          errorInfo: null,
-        });
-        addLog(`[setup] Success - ODA enabled: ${config.enableODA || false}`);
-      } catch (error: any) {
-        set({ error: error.message, errorInfo: null, isSetupInProgress: false });
-        throw error;
+const clearErrorIfUnchanged = (errorBefore: AsleepError | null) => {
+  const current = useAsleepStore.getState().error;
+  if (current !== null && current === errorBefore) useAsleepStore.setState({ error: null });
+};
+
+const normalizeReport = (report: any, sessionId: string): AsleepReport => {
+  const converted = convertKeysToCamelCase(report);
+  if (converted && !converted.session && converted.sessionId) {
+    return {
+      timezone: converted.timezone || "",
+      session: {
+        id: converted.sessionId || converted.id || sessionId,
+        createdTimezone: converted.createdTimezone || "",
+        startTime: converted.sessionStartTime || converted.startTime || "",
+        endTime: converted.sessionEndTime || converted.endTime,
+        unexpectedEndTime: converted.unexpectedEndTime,
+        state: converted.state || "",
+        sleepStages: converted.sleepStages,
+        breathStages: converted.breathStages,
+        snoringStages: converted.snoringStages,
+      },
+      missingDataRatio: converted.missingDataRatio || 0,
+      peculiarities: converted.peculiarities || [],
+      stat: converted.stat,
+    };
+  }
+  return converted as AsleepReport;
+};
+
+export const asleepActions: AsleepActions = {
+  setup: async (config) => {
+    const state = useAsleepStore.getState();
+    if (state.setupStatus === "inProgress") {
+      storeAndThrow(new AsleepError("OPERATION_IN_PROGRESS", "Setup is already in progress."));
+    }
+    if (state.trackingStatus !== "idle") {
+      storeAndThrow(new AsleepError("INVALID_STATE", "Cannot execute setup while tracking is in progress."));
+    }
+
+    const errorBefore = state.error;
+    addLog("[setup] Start");
+    useAsleepStore.setState({ setupStatus: "inProgress" });
+    try {
+      await AsleepModule.setup(config.apiKey, config.baseUrl, config.callbackUrl, config.service, config.enableODA);
+      useAsleepStore.setState({
+        setupStatus: "complete",
+        isODAEnabled: config.enableODA || false,
+        isInitialized: true,
+      });
+      clearErrorIfUnchanged(errorBefore);
+      addLog(`[setup] Success - ODA enabled: ${config.enableODA || false}`);
+    } catch (error) {
+      return guardedFailure(error, "SETUP_FAILED", errorBefore, { setupStatus: "idle" });
+    }
+  },
+
+  initAsleepConfig: async (config) => {
+    const state = useAsleepStore.getState();
+    if (state.setupStatus === "inProgress") {
+      return storeAndThrow(new AsleepError("OPERATION_IN_PROGRESS", "Setup is already in progress."));
+    }
+    if (state.trackingStatus !== "idle") {
+      return storeAndThrow(
+        new AsleepError("INVALID_STATE", "Cannot initialize configuration while tracking is in progress."),
+      );
+    }
+    const errorBefore = state.error;
+    addLog("[initAsleepConfig] Start");
+    useAsleepStore.setState({ setupStatus: "inProgress" });
+    try {
+      await AsleepModule.initAsleepConfig(config.apiKey, config.userId, config.baseUrl, config.callbackUrl);
+      useAsleepStore.setState({ setupStatus: "complete", isInitialized: true });
+      clearErrorIfUnchanged(errorBefore);
+      addLog("[initAsleepConfig] Success");
+    } catch (error) {
+      return guardedFailure(error, "INIT_CONFIG_FAILED", errorBefore, { setupStatus: "idle" });
+    }
+  },
+
+  checkAndRestoreTracking: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    addLog("[checkAndRestoreTracking] Start");
+    try {
+      const isAlive = await AsleepModule.isSleepTrackingAlive();
+      let trackingStatus = useAsleepStore.getState().trackingStatus;
+      if (isAlive && Platform.OS === "android") {
+        const isConnected = await AsleepModule.connectSleepTracking();
+        if (isConnected) trackingStatus = "tracking";
       }
-    },
+      useAsleepStore.setState({ hasCheckedStatus: true, trackingStatus });
+      clearErrorIfUnchanged(errorBefore);
+      addLog(`[checkAndRestoreTracking] Complete - hasActiveSession: ${isAlive}`);
+      return { hasActiveSession: isAlive };
+    } catch (error) {
+      return guardedFailure(error, "CHECK_AND_RESTORE_FAILED", errorBefore);
+    }
+  },
 
-    initAsleepConfig: async (config: AsleepConfig) => {
-      try {
-        const { addLog } = get();
-        addLog("[initAsleepConfig] Start");
-
-        const result = await AsleepModule.initAsleepConfig(
-          config.apiKey,
-          config.userId,
-          config.baseUrl,
-          config.callbackUrl,
-        );
-
-        set({ isInitialized: true, error: null, errorInfo: null });
-        addLog("[initAsleepConfig] Success");
-        return result;
-      } catch (error: any) {
-        set({ error: error.message, errorInfo: null });
-        throw error;
-      }
-    },
-
-    checkAndRestoreTracking: async () => {
-      try {
-        const { addLog } = get();
-        addLog("[checkAndRestoreTracking] Start");
-
-        // Check if sleep tracking service is alive
-        const isAlive = await AsleepModule.isSleepTrackingAlive();
-
-        set({
-          hasCheckedStatus: true,
-        });
-
-        // If service is alive on Android, restore connection to it
-        if (isAlive && Platform.OS === "android") {
-          addLog("[checkAndRestoreTracking] Service is alive, restoring connection...");
-          const isConnected = await AsleepModule.connectSleepTracking();
-
-          if (isConnected) {
-            set({ isTracking: true });
-            addLog("[checkAndRestoreTracking] Successfully restored connection to existing service");
-          } else {
-            addLog("[checkAndRestoreTracking] Failed to restore connection to existing service");
-          }
-        }
-
-        addLog(`[checkAndRestoreTracking] Complete - hasActiveSession: ${isAlive}`);
-        return {
-          hasActiveSession: isAlive,
-        };
-      } catch (error: any) {
-        set({ error: error.message, errorInfo: null });
-        throw error;
-      }
-    },
-
-    /**
-     * Checks battery optimization status on the device.
-     * REQUIRED: Must be called before startTracking() on both iOS and Android.
-     *
-     * This ensures cross-platform consistency - iOS developers must handle
-     * battery optimization to prevent their Android users from experiencing issues.
-     *
-     * @returns Promise with exemption status and platform information
-     * @returns {boolean} exempted - Whether battery optimization is disabled (always true on iOS)
-     * @returns {string} platform - Current platform ('ios' or 'android')
-     * @returns {string} message - Optional status message
-     */
-    checkBatteryOptimization: async () => {
-      const { addLog } = get();
-
-      addLog("[checkBatteryOptimization] Checking battery optimization status...");
-
-      // Mark that check was performed (required for startTracking)
-      set({ hasCheckedBatteryOptimization: true });
-
+  checkBatteryOptimization: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    addLog("[checkBatteryOptimization] Checking battery optimization status...");
+    useAsleepStore.setState({ hasCheckedBatteryOptimization: true });
+    try {
       if (Platform.OS === "ios") {
-        addLog("[checkBatteryOptimization] iOS - not applicable");
+        clearErrorIfUnchanged(errorBefore);
         return { exempted: true, platform: "ios" };
       }
-
-      // Android: Check current status
       const exempted = await AsleepModule.isBatteryOptimizationExempted();
-      addLog(`[checkBatteryOptimization] Exempted: ${exempted}`);
-
+      clearErrorIfUnchanged(errorBefore);
       return {
         exempted,
         platform: "android",
@@ -321,676 +336,486 @@ export const useAsleepStore = create<AsleepState>()(
           ? "Battery optimization disabled - ready for tracking"
           : "Battery optimization must be disabled for reliable tracking",
       };
-    },
+    } catch (error) {
+      return guardedFailure(error, "CHECK_BATTERY_OPTIMIZATION_FAILED", errorBefore);
+    }
+  },
 
-    /**
-     * Requests battery optimization exemption from the user.
-     * On Android: Opens system settings for battery optimization.
-     * On iOS: No-op, returns true (not applicable).
-     *
-     * Use this when checkBatteryOptimization() returns exempted: false.
-     *
-     * @returns Promise<boolean> - true if already exempted or iOS, false if settings opened
-     */
-    requestBatteryOptimizationExemption: async () => {
-      const { addLog } = get();
+  requestBatteryOptimizationExemption: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    if (Platform.OS === "ios") {
+      clearErrorIfUnchanged(errorBefore);
+      return true;
+    }
+    try {
+      const result = await AsleepModule.requestBatteryOptimizationExemption();
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "REQUEST_BATTERY_EXEMPTION_FAILED", errorBefore);
+    }
+  },
 
-      if (Platform.OS === "ios") {
-        addLog("[requestBatteryOptimizationExemption] iOS - not applicable");
-        return true; // Not applicable on iOS
+  startTracking: async (config) => {
+    const state = useAsleepStore.getState();
+    if (!state.hasCheckedStatus) {
+      storeAndThrow(
+        new AsleepError(
+          "MISSING_PREREQUISITE",
+          "Must call checkAndRestoreTracking() at app startup before starting tracking.",
+        ),
+      );
+    }
+    if (!state.hasCheckedBatteryOptimization) {
+      storeAndThrow(
+        new AsleepError("MISSING_PREREQUISITE", "Must call checkBatteryOptimization() before starting tracking."),
+      );
+    }
+    if (state.setupStatus === "inProgress") {
+      storeAndThrow(new AsleepError("INVALID_STATE", "Cannot start tracking while setup is in progress."));
+    }
+    if (state.trackingStatus !== "idle") {
+      storeAndThrow(new AsleepError("OPERATION_IN_PROGRESS", "Tracking is already in progress."));
+    }
+
+    const errorBefore = state.error;
+    try {
+      if (!(await asleepActions.hasRequiredPermissions())) {
+        const message =
+          Platform.OS === "android" && Platform.Version >= 33
+            ? "Microphone and notification permissions are required. Call requestRequiredPermissions() before startTracking()."
+            : "Microphone permission is required. Call requestRequiredPermissions() before startTracking().";
+        storeAndThrow(new AsleepError("PERMISSION_DENIED", message));
       }
 
-      addLog("[requestBatteryOptimizationExemption] Opening battery settings...");
-
-      // This just opens settings, doesn't wait
-      // Returns true if already exempted, false if settings opened
-      return await AsleepModule.requestBatteryOptimizationExemption();
-    },
-
-    /**
-     * Starts sleep tracking session.
-     *
-     * Prerequisites:
-     * 1. checkAndRestoreTracking() must be called at app startup
-     * 2. checkBatteryOptimization() must be called (required on both platforms)
-     *
-     * @param config Optional tracking configuration
-     * @throws Error if prerequisites are not met or tracking is already in progress
-     */
-    startTracking: async (config?: TrackingConfig) => {
-      // Snapshot so the catch can tell a verdict published DURING this call
-      // (Android fires classified onTrackingFailed before rejecting the same
-      // promise) apart from a stale one left by an earlier failure.
-      const errorInfoBefore = get().errorInfo;
-      try {
-        const { requestRequiredPermissions, addLog, isODAEnabled, isSetupInProgress, hasCheckedStatus } = get();
-
-        // Enforce that checkAndRestoreTracking must be called first
-        if (!hasCheckedStatus) {
-          addLog("[startTracking] Must call checkAndRestoreTracking() at app startup");
-          throw new Error("Must call checkAndRestoreTracking() at app startup before starting tracking");
-        }
-
-        // Enforce battery optimization check on BOTH platforms for consistency
-        // This ensures iOS developers handle battery optimization for their Android users
-        if (!get().hasCheckedBatteryOptimization) {
-          addLog("[startTracking] ERROR: Must check battery optimization first");
-          throw new Error(
-            "Must call checkBatteryOptimization() before starting tracking. " +
-              "This check is required on both iOS and Android to ensure cross-platform consistency.",
-          );
-        }
-
-        // Block startTracking execution if setup is in progress
-        if (isSetupInProgress) {
-          addLog("[startTracking] Cannot start tracking while setup is in progress.");
-          throw new Error("Cannot start tracking while setup is in progress.");
-        }
-
-        // Prevent duplicate execution if already tracking
-        if (get().isTracking) {
-          addLog("[startTracking] Tracking is already in progress.");
-          throw new Error("Tracking is already in progress.");
-        }
-
-        addLog("[startTracking] Start");
-
-        const permission = await requestRequiredPermissions();
-        if (!permission) {
-          // SDK shouldn't show UI directly - throw specific error message
-          if (Platform.OS === "android" && Platform.Version >= 33) {
-            throw new Error("Microphone and notification permissions are required for sleep tracking");
-          } else {
-            throw new Error("Microphone permission is required for sleep tracking");
-          }
-        }
-
-        // Always verify CURRENT exemption status
-        if (Platform.OS === "android") {
-          const batteryExempted = await AsleepModule.isBatteryOptimizationExempted();
-          if (!batteryExempted) {
-            addLog("[startTracking] ERROR: Battery optimization not disabled");
-            throw new Error(
-              "Battery optimization must be disabled for reliable sleep tracking. " +
-                "Call requestBatteryOptimizationExemption() to guide user to settings.",
-            );
-          }
-          addLog("[startTracking] Battery optimization exempted - OK");
-        }
-
-        set({
-          didClose: false,
-          isTracking: true,
-          isAnalyzing: false,
-          isRecoveryRequired: false,
-          trackingStartTime: new Date(),
-          error: null,
-          errorInfo: null,
-        });
-        await AsleepModule.startTracking(config);
-
-        if (isODAEnabled) {
-          addLog("[startTracking] ODA enabled - real-time analysis will start automatically");
-        } else {
-          addLog("[startTracking] ODA not enabled");
-        }
-
-        addLog("[startTracking] Success");
-      } catch (error: any) {
-        // Preserve only a verdict that arrived during this call — the raw
-        // rejection message carries strictly less information than the
-        // numeric-code verdict. Reference inequality against the snapshot
-        // excludes stale verdicts, so guard failures still write the new error.
-        const nowInfo = get().errorInfo;
-        const classified = nowInfo !== null && nowInfo !== errorInfoBefore;
-        set({
-          ...(classified ? {} : { error: error.message, errorInfo: null }),
-          isTracking: false,
-          isAnalyzing: false,
-          trackingStartTime: null,
-        });
-        throw error;
-      }
-    },
-
-    stopTracking: async () => {
-      // Same dual-signal race as startTracking; see the snapshot rationale there.
-      const errorInfoBefore = get().errorInfo;
-      try {
-        const { addLog } = get();
-        addLog("[stopTracking] Start");
-
-        const result = await AsleepModule.stopTracking();
-        set({
-          didClose: true,
-          ...(result ? { sessionId: result } : {}),
-          isTracking: false,
-          isAnalyzing: false,
-          isRecoveryRequired: false,
-          trackingStartTime: null,
-          error: null,
-          errorInfo: null,
-        });
-
-        addLog(`[stopTracking] Success - result: ${result}`);
-      } catch (error: any) {
-        const nowInfo = get().errorInfo;
-        if (nowInfo === null || nowInfo === errorInfoBefore) set({ error: error.message, errorInfo: null });
-        throw error;
-      }
-    },
-
-    resumeTracking: async () => {
-      if (Platform.OS !== "ios") {
-        throw Object.assign(new Error("resumeTracking is only supported on iOS."), {
-          name: "AsleepPlatformError",
-          code: "UNSUPPORTED_PLATFORM",
-        });
+      if (Platform.OS === "android" && !(await AsleepModule.isBatteryOptimizationExempted())) {
+        storeAndThrow(
+          new AsleepError(
+            "BATTERY_NOT_EXEMPTED",
+            "Battery optimization must be disabled before startTracking(). Call requestBatteryOptimizationExemption().",
+          ),
+        );
       }
 
+      useAsleepStore.setState({
+        didClose: false,
+        trackingStatus: "tracking",
+        isAnalyzing: false,
+        trackingStartTime: new Date(),
+      });
+      await AsleepModule.startTracking(config);
+      clearErrorIfUnchanged(errorBefore);
+      addLog("[startTracking] Success");
+    } catch (error) {
+      return guardedFailure(error, "START_TRACKING_FAILED", errorBefore, {
+        trackingStatus: "idle",
+        isAnalyzing: false,
+        trackingStartTime: null,
+      });
+    }
+  },
+
+  stopTracking: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      const result = await AsleepModule.stopTracking();
+      useAsleepStore.setState({
+        didClose: true,
+        ...(typeof result === "string" && result ? { sessionId: result } : {}),
+        trackingStatus: "idle",
+        isAnalyzing: false,
+        trackingStartTime: null,
+      });
+      clearErrorIfUnchanged(errorBefore);
+      addLog(`[stopTracking] Success - result: ${result}`);
+    } catch (error) {
+      return guardedFailure(error, "STOP_TRACKING_FAILED", errorBefore);
+    }
+  },
+
+  resumeTracking: async () => {
+    if (Platform.OS !== "ios") {
+      storeAndThrow(new AsleepError("UNSUPPORTED_PLATFORM", "resumeTracking is only supported on iOS."));
+    }
+    const errorBefore = useAsleepStore.getState().error;
+    try {
       await AsleepModule.resumeTracking();
-    },
+      clearErrorIfUnchanged(errorBefore);
+    } catch (error) {
+      return guardedFailure(error, "RESUME_TRACKING_FAILED", errorBefore);
+    }
+  },
 
-    getReport: async (sessionId: string) => {
-      // Snapshot the error before the await so we only clear it on success
-      // if no concurrent failure (e.g. onTrackingFailed firing during the
-      // network round-trip) wrote a different error in the meantime.
-      const errorBefore = get().error;
-      try {
-        const { addLog } = get();
-        addLog(`[getReport] sessionId: ${sessionId}`);
+  getReport: async (sessionId) => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      const report = normalizeReport(await AsleepModule.getReport(sessionId), sessionId);
+      clearErrorIfUnchanged(errorBefore);
+      return report;
+    } catch (error) {
+      return guardedFailure(error, "GET_REPORT_FAILED", errorBefore);
+    }
+  },
 
-        const report = await AsleepModule.getReport(sessionId);
-        const convertedReport = convertKeysToCamelCase(report);
+  getReportList: async (fromDate, toDate) => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      const reportList = await AsleepModule.getReportList(fromDate, toDate);
+      const result = reportList.map((session: any) => {
+        const converted = convertKeysToCamelCase(session);
+        return {
+          id: converted.sessionId || converted.id,
+          state: converted.state,
+          startTime: converted.sessionStartTime || converted.startTime,
+          endTime: converted.sessionEndTime || converted.endTime,
+          createdTimezone: converted.createdTimezone,
+          unexpectedEndTime: converted.unexpectedEndTime,
+          lastReceivedSeqNum: converted.lastReceivedSeqNum,
+          timeInBed: converted.timeInBed,
+        };
+      });
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "GET_REPORT_LIST_FAILED", errorBefore);
+    }
+  },
 
-        addLog("[getReport] Success");
-        // Guard so a successful query after a clean run does not spam an empty
-        // notification, and so we never clobber an unrelated tracking error
-        // that arrived during the await.
-        if (get().error !== null && get().error === errorBefore) set({ error: null, errorInfo: null });
+  getAverageReport: async (fromDate, toDate) => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      const result = convertKeysToCamelCase(await AsleepModule.getAverageReport(fromDate, toDate));
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "GET_AVERAGE_REPORT_FAILED", errorBefore);
+    }
+  },
 
-        // Ensure the report has the expected AsleepReport structure
-        // Handle cases where native modules might return data in different formats
-        if (convertedReport && !convertedReport.session && convertedReport.sessionId) {
-          // If the data comes in a flat format (like AsleepSession), convert it to AsleepReport format
-          const normalizedReport: AsleepReport = {
-            timezone: convertedReport.timezone || "",
-            session: {
-              id: convertedReport.sessionId || convertedReport.id || sessionId,
-              createdTimezone: convertedReport.createdTimezone || "",
-              startTime: convertedReport.sessionStartTime || convertedReport.startTime || "",
-              endTime: convertedReport.sessionEndTime || convertedReport.endTime,
-              unexpectedEndTime: convertedReport.unexpectedEndTime,
-              state: convertedReport.state || "",
-              sleepStages: convertedReport.sleepStages,
-              breathStages: convertedReport.breathStages,
-              snoringStages: convertedReport.snoringStages,
-            },
-            missingDataRatio: convertedReport.missingDataRatio || 0,
-            peculiarities: convertedReport.peculiarities || [],
-            stat: convertedReport.stat,
-          };
-          return normalizedReport;
-        }
+  deleteSession: async (sessionId) => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      await AsleepModule.deleteSession(sessionId);
+      clearErrorIfUnchanged(errorBefore);
+    } catch (error) {
+      return guardedFailure(error, "DELETE_SESSION_FAILED", errorBefore);
+    }
+  },
 
-        return convertedReport as AsleepReport;
-      } catch (error: any) {
-        // Silent return on failure is a public-API quirk preserved for v1.x
-        // compat (v2.0 throws). Surface a dev-only warn so the consumer's
-        // Metro log still shows the failure when they're debugging without
-        // observing `useAsleep().error` directly.
-        if (typeof __DEV__ !== "undefined" && __DEV__) console.warn("[Asleep] getReport failed:", error);
-        set({ error: error.message, errorInfo: null });
-        return null;
-      }
-    },
+  requestAnalysis: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    useAsleepStore.setState({ isAnalyzing: true });
+    try {
+      const result = convertKeysToCamelCase(await AsleepModule.requestAnalysis());
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "REQUEST_ANALYSIS_FAILED", errorBefore, { isAnalyzing: false });
+    }
+  },
 
-    getReportList: async (fromDate: string, toDate: string) => {
-      const errorBefore = get().error;
-      try {
-        const { addLog } = get();
-        addLog(`[getReportList] fromDate: ${fromDate}, toDate: ${toDate}`);
+  hasRequiredPermissions: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
+      const result = await AsleepModule.hasRequiredPermissions();
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "CHECK_PERMISSION_FAILED", errorBefore);
+    }
+  },
 
-        const reportList = await AsleepModule.getReportList(fromDate, toDate);
-        const convertedList = reportList.map((session: any) => {
-          const converted = convertKeysToCamelCase(session);
-          // Normalize property names to match other session types
-          return {
-            id: converted.sessionId || converted.id,
-            state: converted.state,
-            startTime: converted.sessionStartTime || converted.startTime,
-            endTime: converted.sessionEndTime || converted.endTime,
-            createdTimezone: converted.createdTimezone,
-            unexpectedEndTime: converted.unexpectedEndTime,
-            lastReceivedSeqNum: converted.lastReceivedSeqNum,
-            timeInBed: converted.timeInBed,
-          };
-        });
-
-        addLog("[getReportList] Success");
-        if (get().error !== null && get().error === errorBefore) set({ error: null, errorInfo: null });
-        return convertedList;
-      } catch (error: any) {
-        if (typeof __DEV__ !== "undefined" && __DEV__) console.warn("[Asleep] getReportList failed:", error);
-        set({ error: error.message, errorInfo: null });
-        return [];
-      }
-    },
-
-    deleteSession: async (sessionId: string) => {
-      const errorBefore = get().error;
-      try {
-        const { addLog } = get();
-        addLog(`[deleteSession] sessionId: ${sessionId}`);
-
-        await AsleepModule.deleteSession(sessionId);
-
-        addLog("[deleteSession] Success");
-        if (get().error !== null && get().error === errorBefore) set({ error: null, errorInfo: null });
-      } catch (error: any) {
-        set({ error: error.message, errorInfo: null });
-        throw error;
-      }
-    },
-
-    getAverageReport: async (fromDate: string, toDate: string) => {
-      const errorBefore = get().error;
-      try {
-        const { addLog } = get();
-        addLog(`[getAverageReport] fromDate: ${fromDate}, toDate: ${toDate}`);
-
-        const averageReport = await AsleepModule.getAverageReport(fromDate, toDate);
-        const convertedReport = convertKeysToCamelCase(averageReport);
-
-        addLog("[getAverageReport] Success");
-        if (get().error !== null && get().error === errorBefore) set({ error: null, errorInfo: null });
-        return convertedReport;
-      } catch (error: any) {
-        if (typeof __DEV__ !== "undefined" && __DEV__) console.warn("[Asleep] getAverageReport failed:", error);
-        set({ error: error.message, errorInfo: null });
-        return null;
-      }
-    },
-
-    /**
-     * @deprecated Use requestRequiredPermissions instead. This method will be removed in a future version.
-     */
-    requestMicrophonePermission: async () => {
-      if (typeof __DEV__ !== "undefined" && __DEV__) {
-        console.warn(
-          "[Asleep] requestMicrophonePermission is deprecated. Please use requestRequiredPermissions instead.",
-        );
-      }
-      return get().requestRequiredPermissions();
-    },
-
-    requestRequiredPermissions: async () => {
+  requestRequiredPermissions: async () => {
+    const errorBefore = useAsleepStore.getState().error;
+    try {
       if (Platform.OS === "android") {
-        try {
-          // Prepare permissions array with RECORD_AUDIO
-          const permissions = [PermissionsAndroid.PERMISSIONS.RECORD_AUDIO];
-
-          // Add POST_NOTIFICATIONS for Android 13+ (API level 33)
-          if (Platform.Version >= 33) {
-            permissions.push(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
-          }
-
-          // Request all permissions together for better UX (single dialog)
-          const results = await PermissionsAndroid.requestMultiple(permissions);
-
-          // Check if all required permissions are granted
-          const audioGranted =
-            results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED;
-
-          const notificationGranted =
-            Platform.Version >= 33
-              ? results[PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS] === PermissionsAndroid.RESULTS.GRANTED
-              : true;
-
-          // Both must be granted for tracking to work properly
-          return audioGranted && notificationGranted;
-        } catch (err) {
-          if (typeof __DEV__ !== "undefined" && __DEV__) console.warn("[Asleep] Permission request error:", err);
-          return false;
-        }
+        const permissions = [PermissionsAndroid.PERMISSIONS.RECORD_AUDIO];
+        if (Platform.Version >= 33) permissions.push(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+        const results = await PermissionsAndroid.requestMultiple(permissions);
+        const audioGranted =
+          results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED;
+        const notificationGranted =
+          Platform.Version >= 33
+            ? results[PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS] === PermissionsAndroid.RESULTS.GRANTED
+            : true;
+        clearErrorIfUnchanged(errorBefore);
+        return audioGranted && notificationGranted;
       }
-      // iOS uses native implementation
-      return AsleepModule.requestRequiredPermissions();
-    },
+      const result = await AsleepModule.requestRequiredPermissions();
+      clearErrorIfUnchanged(errorBefore);
+      return result;
+    } catch (error) {
+      return guardedFailure(error, "REQUEST_PERMISSION_FAILED", errorBefore);
+    }
+  },
 
-    setCustomNotification: async (_title: string, _text: string) => {
-      // Native method removed; notification config now flows through startTracking options.
-      if (typeof __DEV__ !== "undefined" && __DEV__)
-        console.warn(
-          "[Asleep] setCustomNotification is deprecated and a no-op; pass `{ android: { notification: { title, text, icon } } }` to startTracking() instead",
-        );
-    },
+  setCustomNotification: async (_title, _text) => {
+    if (typeof __DEV__ !== "undefined" && __DEV__) {
+      console.warn(
+        "[Asleep] setCustomNotification is deprecated and a no-op; pass notification options to startTracking() instead.",
+      );
+    }
+  },
 
-    enableLog: (print: boolean) => {
-      if (Platform.OS === "ios") AsleepModule.enableLog(print);
-      set({ showDebugLog: print });
-    },
+  enableLog: (print) => {
+    if (Platform.OS === "ios") AsleepModule.enableLog(print);
+    useAsleepStore.setState({ showDebugLog: print });
+  },
 
-    requestAnalysis: async () => {
-      try {
-        const { addLog, showDebugLog } = get();
-        addLog("[requestAnalysis] Start");
+  clearError: () => useAsleepStore.setState({ error: null }),
 
-        set({ isAnalyzing: true, error: null, errorInfo: null });
+  addEventListener: (eventType, listener) => {
+    const subscription = emitter.addListener(eventType, listener);
+    return () => subscription.remove();
+  },
+};
 
-        const result = await AsleepModule.requestAnalysis();
-        const convertedResult = convertKeysToCamelCase(result);
+let lastInternal: InternalAsleepState | null = null;
+let lastPublic: AsleepPublicApi | null = null;
 
-        // analysisResult and isAnalyzing are owned by the onAnalysisResult event handler on both
-        // platforms. Android resolves the promise with the full session AND fires the event;
-        // iOS resolves with an ack only. Writing state here would double-update on Android.
+export const toPublicState = (internal: InternalAsleepState): AsleepPublicApi => {
+  if (internal === lastInternal && lastPublic) return lastPublic;
+  // Recovery-required is still a live native session on main; preserve that
+  // contract while representing the recovery fact with one enum value.
+  const isTracking = internal.trackingStatus !== "idle";
+  const next: AsleepPublicApi = {
+    status: internal.trackingStatus,
+    isTracking,
+    isTrackingPaused: internal.trackingStatus === "paused",
+    isRecoveryRequired: internal.trackingStatus === "recoveryRequired",
+    isSetupInProgress: internal.setupStatus === "inProgress",
+    isSetupComplete: internal.setupStatus === "complete",
+    sessionId: internal.sessionId,
+    userId: internal.userId,
+    error: internal.error,
+    analysisResult: internal.analysisResult,
+    isAnalyzing: internal.isAnalyzing,
+    didClose: internal.didClose,
+    isODAEnabled: internal.isODAEnabled,
+    log: internal.log,
+    ...asleepActions,
+  };
+  lastInternal = internal;
+  if (
+    lastPublic &&
+    lastPublic.status === next.status &&
+    lastPublic.sessionId === next.sessionId &&
+    lastPublic.userId === next.userId &&
+    lastPublic.error === next.error &&
+    lastPublic.analysisResult === next.analysisResult &&
+    lastPublic.isAnalyzing === next.isAnalyzing &&
+    lastPublic.didClose === next.didClose &&
+    lastPublic.isODAEnabled === next.isODAEnabled &&
+    lastPublic.log === next.log &&
+    lastPublic.isSetupInProgress === next.isSetupInProgress &&
+    lastPublic.isSetupComplete === next.isSetupComplete
+  ) {
+    return lastPublic;
+  }
+  lastPublic = next;
+  return lastPublic;
+};
 
-        if (showDebugLog) addLog(`[requestAnalysis] Request sent - ${JSON.stringify(convertedResult)}`);
+type EventName = keyof AsleepEventType;
 
-        return convertedResult;
-      } catch (error: any) {
-        if (typeof __DEV__ !== "undefined" && __DEV__) console.warn("[Asleep] requestAnalysis failed:", error);
-        set({ error: error.message, errorInfo: null, isAnalyzing: false });
-        return null;
+const transitionForEvent = (
+  eventType: EventName,
+  payload: any,
+  state: InternalAsleepState,
+): { partial: Partial<InternalAsleepState>; log: string; requestAnalysis?: boolean } => {
+  switch (eventType) {
+    case "onUserJoined":
+      return { partial: { userId: payload.userId }, log: `[onUserJoined] userId: ${payload.userId}` };
+    case "onUserJoinFailed":
+      return {
+        partial: { error: normalizeError(payload, "USER_JOIN_FAILED") },
+        log: `[onUserJoinFailed] error: ${payload?.message ?? payload?.detail ?? payload?.error ?? "Unknown error"}`,
+      };
+    case "onUserDeleted":
+      return { partial: { userId: null }, log: `[onUserDeleted] userId: ${payload.userId}` };
+    case "onTrackingCreated":
+      return {
+        partial: { trackingStatus: "tracking", ...(payload?.sessionId ? { sessionId: payload.sessionId } : {}) },
+        log: `[onTrackingCreated]${payload?.sessionId ? ` sessionId: ${payload.sessionId}` : ""}`,
+      };
+    case "onTrackingUploaded": {
+      const shouldAnalyze =
+        state.trackingStatus !== "idle" &&
+        (state.isODAEnabled || (payload.sequence >= 10 && payload.sequence % 10 === 1));
+      return {
+        partial: {
+          // iOS 3.2.0 emits didResume before its engine restart is proven.
+          // Only a completed upload clears recovery; see AGENTS.md
+          // "Native Behavior Compensations".
+          ...(state.trackingStatus === "recoveryRequired" ? { trackingStatus: "tracking" as const } : {}),
+          ...(shouldAnalyze ? { isAnalyzing: true } : {}),
+        },
+        log: `[onTrackingUploaded] sequence: ${payload.sequence}`,
+        requestAnalysis: shouldAnalyze,
+      };
+    }
+    case "onTrackingClosed":
+      return {
+        partial: {
+          sessionId: payload.sessionId,
+          trackingStatus: "idle",
+          isAnalyzing: false,
+          didClose: true,
+          trackingStartTime: null,
+        },
+        log: `[onTrackingClosed] sessionId: ${payload.sessionId}`,
+      };
+    case "onTrackingFailed": {
+      const recordingDead = !!payload && RECORDING_DEAD_ERROR_CODES.has(payload.code);
+      const recoveryRequired = !!payload && RECOVERY_REQUIRED_ERROR_CODES.has(payload.code);
+      const terminal =
+        !!payload &&
+        !recordingDead &&
+        !recoveryRequired &&
+        (TERMINAL_TRACKING_ERROR_CODES.has(payload.code) || TERMINAL_TRACKING_SDK_CODES.has(payload.sdkCode));
+      const transient = !!payload && TRANSIENT_TRACKING_SDK_CODES.has(payload.sdkCode);
+      const category: AsleepErrorCategory = recordingDead
+        ? "recordingDead"
+        : recoveryRequired
+          ? "recoveryRequired"
+          : terminal
+            ? "terminal"
+            : transient
+              ? "transient"
+              : "unknown";
+      const error = normalizeError(payload, "TRACKING_FAILED", {
+        category,
+        sdkCode: typeof payload?.sdkCode === "number" ? payload.sdkCode : undefined,
+        caseName: typeof payload?.caseName === "string" ? payload.caseName : undefined,
+      });
+
+      if (terminal) {
+        return {
+          partial: {
+            // iOS 3.2.1 closeSessionSilently does not emit didClose, so this
+            // branch must clear the projected session state itself.
+            error,
+            trackingStatus: "idle",
+            isAnalyzing: false,
+            didClose: true,
+            trackingStartTime: null,
+          },
+          log: `[onTrackingError] error: ${error.message}`,
+        };
       }
-    },
+      if (recordingDead) {
+        return {
+          partial: {
+            // iOS 3.2.0 audioInitializationFailed stops its recorder but
+            // intentionally keeps the native session open (didClose=false).
+            error,
+            trackingStatus: "idle",
+            isAnalyzing: false,
+            didClose: false,
+            trackingStartTime: null,
+          },
+          log: `[onTrackingError] error: ${error.message}`,
+        };
+      }
+      if (recoveryRequired) {
+        return {
+          // iOS 3.2.0 cannotActivateInBackground keeps the session alive and
+          // requires an explicit foreground resume.
+          partial: { error, trackingStatus: "recoveryRequired" },
+          log: `[onTrackingError] error: ${error.message}`,
+        };
+      }
+      return { partial: { error }, log: `[onTrackingError] error: ${error.message}` };
+    }
+    case "onTrackingInterrupted":
+      return { partial: { trackingStatus: "paused" }, log: "[onTrackingInterrupted]" };
+    case "onTrackingResumed":
+      return {
+        partial: {
+          error: null,
+          // iOS 3.2.1 can emit didResume twice. Always clear the error, but
+          // mutate the paused state only for the first event.
+          ...(state.trackingStatus === "paused" ? { trackingStatus: "tracking" as const } : {}),
+        },
+        log:
+          state.trackingStatus === "paused"
+            ? "[onTrackingResumed]"
+            : "[onTrackingResumed] (no prior pause; error cleared)",
+      };
+    case "onMicPermissionDenied":
+      return { partial: {}, log: "[onMicPermissionDenied]" };
+    case "onDebugLog":
+      return { partial: {}, log: `[onDebugLog] message: ${payload.message}` };
+    case "onSetupDidComplete":
+      return { partial: { setupStatus: "complete" }, log: "[onSetupDidComplete]" };
+    case "onSetupDidFail":
+      return {
+        partial: { error: normalizeError(payload, "SETUP_FAILED"), setupStatus: "idle" },
+        log: `[onSetupDidFail] error: ${payload?.message ?? payload?.error ?? "Unknown error"}`,
+      };
+    case "onSetupInProgress":
+      return { partial: { setupStatus: "inProgress" }, log: `[onSetupInProgress] progress: ${payload.progress}%` };
+    case "onAnalysisResult": {
+      // Android SDK 3.2.x emits snake_case while iOS emits camelCase.
+      const analysisResult = convertKeysToCamelCase(payload);
+      return {
+        partial: { analysisResult, isAnalyzing: false },
+        log: `[onAnalysisResult] ${JSON.stringify(analysisResult)}`,
+      };
+    }
+  }
+};
 
-    addEventListener: <K extends keyof AsleepEventType>(eventType: K, listener: (data: AsleepEventType[K]) => void) => {
-      const subscription = emitter.addListener(eventType, listener);
-      return () => subscription.remove();
-    },
+const applyEvent = (eventType: EventName, payload: unknown) => {
+  const state = useAsleepStore.getState();
+  const transition = transitionForEvent(eventType, payload, state);
+  useAsleepStore.setState({ ...transition.partial, ...logPartial(transition.log, state) });
+  if (transition.requestAnalysis) {
+    void asleepActions.requestAnalysis().catch((error) => {
+      addLog(`[onTrackingUploaded] Auto analysis failed: ${error.message}`);
+    });
+  }
+};
 
-    getTrackingDurationMinutes: () => {
-      const { trackingStartTime } = get();
-      if (!trackingStartTime) return 0;
-      return Math.floor((Date.now() - trackingStartTime.getTime()) / (1000 * 60));
-    },
-
-    // internal actions
-    // setError takes a raw string, so any structured classification is stale;
-    // reset errorInfo rather than let a previous event's category linger.
-    setError: (error) => set({ error, errorInfo: null }),
-    clearError: () => set({ error: null, errorInfo: null }),
-    setUserId: (userId) => set({ userId }),
-    setSessionId: (sessionId) => set({ sessionId }),
-    setIsTracking: (isTracking) => set({ isTracking }),
-    setIsTrackingPaused: (isTrackingPaused) => set({ isTrackingPaused }),
-    setDidClose: (didClose) => set({ didClose }),
-    setAnalysisResult: (result) => set({ analysisResult: result }),
-    setIsAnalyzing: (isAnalyzing) => set({ isAnalyzing }),
-    setTrackingStartTime: (time) => set({ trackingStartTime: time }),
-    setIsInitialized: (initialized) => set({ isInitialized: initialized }),
-    setIsSetupInProgress: (inProgress) => set({ isSetupInProgress: inProgress }),
-    setIsSetupComplete: (complete) => set({ isSetupComplete: complete }),
-    setHasCheckedStatus: (checked) => set({ hasCheckedStatus: checked }),
-    setHasCheckedBatteryOptimization: (checked) => set({ hasCheckedBatteryOptimization: checked }),
-
-    addLog: (log: string) => {
-      // Zero-cost when the consumer has not opted into debug logging. Without
-      // this guard, every native event handler would cause a spurious
-      // subscriber notification on top of any actual data update.
-      const { showDebugLog } = get();
-      if (!showDebugLog) return;
-      const now = new Date();
-      const dateString = `${now.getHours().toString().padStart(2, "0")}:${now
-        .getMinutes()
-        .toString()
-        .padStart(2, "0")}:${now.getSeconds().toString().padStart(2, "0")}`;
-      const formattedLog = `[${dateString}]${log}`;
-      console.log(`[Asleep]${formattedLog}`);
-      set({ log: formattedLog });
-    },
-  })),
-);
-
-// Ref-counted registration. Each caller (useAsleep effect, background context,
-// etc.) increments on entry and decrements via the returned cleanup. Native
-// listeners only attach on 0→1 and detach on the final 1→0, so concurrent
-// consumers cannot tear each other's subscriptions down.
 let refCount = 0;
 let teardown: (() => void) | null = null;
 
 export const initializeAsleepListeners = (): (() => void) => {
-  // Cold start when no teardown is installed. `teardown` is the single source
-  // of truth for "listeners are currently attached"; refCount is just an
-  // increment-only counter for cleanup balancing. Always incrementing
-  // (instead of assigning =1 on cold start) keeps the count correct even if
-  // a future change introduces an async seam between this check and the
-  // listener registration below.
   if (teardown) {
     refCount++;
     return makeCleanup();
   }
 
-  const store = useAsleepStore.getState();
-  const { addLog, setUserId, setIsTrackingPaused, setIsSetupInProgress } = store;
-
-  // event handlers — each native SDK event corresponds to one logical state
-  // transaction. Use a single useAsleepStore.setState per handler so consumers
-  // subscribed via useAsleep re-render once per event, not once per field.
-  const handlers = {
-    // Connected: iOS userDidJoin, Android onSuccess (AsleepConfigListener)
-    onUserJoined: (data: any) => {
-      setUserId(data.userId);
-      addLog(`[onUserJoined] userId: ${data.userId}`);
-    },
-    // Connected: iOS didFailUserJoin, Android onFail (AsleepConfigListener)
-    onUserJoinFailed: (error: any) => {
-      const errorString = JSON.stringify(error);
-      // Not a tracking-runtime failure; errorInfo stays reserved for
-      // onTrackingFailed classification.
-      useAsleepStore.setState({ error: errorString, errorInfo: null });
-      addLog(`[onUserJoinFailed] error: ${errorString}`);
-    },
-    // Connected: iOS userDidDelete, Android NOT IMPLEMENTED
-    onUserDeleted: (data: any) => {
-      setUserId(null);
-      addLog(`[onUserDeleted] userId: ${data.userId}`);
-    },
-    // Connected: iOS didCreate, Android onStart (AsleepTrackingListener)
-    onTrackingCreated: (data: any) => {
-      useAsleepStore.setState({
-        isTracking: true,
-        ...(data?.sessionId ? { sessionId: data.sessionId } : {}),
-      });
-      addLog(`[onTrackingCreated]${data?.sessionId ? ` sessionId: ${data.sessionId}` : ""}`);
-    },
-    // Connected: iOS didUpload, Android onPerform (AsleepTrackingListener)
-    // Triggers automatic analysis requests in both ODA and non-ODA modes
-    onTrackingUploaded: (data: any) => {
-      addLog(`[onTrackingUploaded] sequence: ${data.sequence}`);
-
-      // requestAnalysis() flips isAnalyzing internally; no separate setter
-      // needed before invoking it (avoids a duplicate subscriber notification).
-      const state = useAsleepStore.getState();
-      // A completed upload is the only positive proof that recording actually came
-      // back — didResume fires before the engine restart is even attempted, so it
-      // cannot be trusted to clear this.
-      if (state.isRecoveryRequired) useAsleepStore.setState({ isRecoveryRequired: false });
-      const triggerAnalysis = () =>
-        state.requestAnalysis().catch((error) => {
-          addLog(`[onTrackingUploaded] Auto analysis failed: ${error.message}`);
-          state.setIsAnalyzing(false);
-        });
-
-      if (state.isODAEnabled && state.isTracking) {
-        triggerAnalysis();
-      } else if (!state.isODAEnabled && state.isTracking) {
-        if (data.sequence >= 10 && data.sequence % 10 === 1) {
-          triggerAnalysis();
-        }
-      }
-    },
-    // Connected: iOS didClose, Android onFinish (AsleepTrackingListener)
-    onTrackingClosed: (data: { sessionId: string }) => {
-      useAsleepStore.setState({
-        sessionId: data.sessionId,
-        isTracking: false,
-        isAnalyzing: false,
-        isRecoveryRequired: false,
-        didClose: true,
-        trackingStartTime: null,
-      });
-      addLog(`[onTrackingClosed] sessionId: ${data.sessionId}`);
-    },
-    // Connected: iOS didFail, Android onFail (AsleepTrackingListener)
-    // Four state buckets, each writing tracking state in the same setState as the
-    // error so subscribers see one event: terminal (native session already gone),
-    // recording-dead (recorder torn down but session still open — clearing
-    // isTracking is what unblocks a restart), recovery-required (resumeTracking()
-    // in foreground can revive it), and everything else (error only).
-    // The two dead-session buckets must also clear isRecoveryRequired: iOS retries
-    // cannotActivateInBackground and then gives up with interruptionRecoveryFailed,
-    // and no upload will ever arrive to clear the flag on that path.
-    // The bucket verdict is also published as errorInfo.category (with the
-    // else-bucket split into "transient" vs "unknown") so consumers can gate
-    // log severity on data instead of re-deriving code lists themselves.
-    onTrackingFailed: (error: any) => {
-      // The explicit iOS string buckets must win before the numeric terminal
-      // fallback: the numeric set encodes Android teardown semantics, and iOS
-      // reuses 11003 (.audioInitializationFailed -> .audio) for a failure whose
-      // session is still open. The numeric fallback still matters on iOS for
-      // start/stop failures that arrive as UNKNOWN_ERROR + 22xxx/24xxx and must
-      // clear the optimistically-set isTracking.
-      const recordingDead = !!(error && RECORDING_DEAD_ERROR_CODES.has(error.code));
-      const recoveryRequired = !!(error && RECOVERY_REQUIRED_ERROR_CODES.has(error.code));
-      const terminal = !!(
-        error &&
-        !recordingDead &&
-        !recoveryRequired &&
-        (TERMINAL_TRACKING_ERROR_CODES.has(error.code) || TERMINAL_TRACKING_SDK_CODES.has(error.sdkCode))
-      );
-      const transient = !!(error && TRANSIENT_TRACKING_SDK_CODES.has(error.sdkCode));
-
-      let category: AsleepErrorCategory;
-      if (recordingDead) category = "recordingDead";
-      else if (recoveryRequired) category = "recoveryRequired";
-      else if (terminal) category = "terminal";
-      else if (transient) category = "transient";
-      else category = "unknown";
-
-      // Category rides along in the stringified error too, so consumers still
-      // parsing the legacy string see the same verdict as errorInfo readers.
-      const errorString = JSON.stringify(error ? { ...error, category } : error);
-      const errorInfo: AsleepErrorInfo | null = error
-        ? {
-            code: typeof error.code === "string" ? error.code : "UNKNOWN_ERROR",
-            category,
-            ...(typeof error.sdkCode === "number" ? { sdkCode: error.sdkCode } : {}),
-            ...(typeof error.message === "string" ? { message: error.message } : {}),
-            ...(typeof error.caseName === "string" ? { caseName: error.caseName } : {}),
-          }
-        : null;
-
-      let nextState: Partial<AsleepState>;
-      if (terminal) {
-        nextState = {
-          error: errorString,
-          errorInfo,
-          isTracking: false,
-          isAnalyzing: false,
-          isRecoveryRequired: false,
-          didClose: true,
-          trackingStartTime: null,
-        };
-      } else if (recordingDead) {
-        nextState = {
-          error: errorString,
-          errorInfo,
-          isTracking: false,
-          isAnalyzing: false,
-          isRecoveryRequired: false,
-          didClose: false,
-          trackingStartTime: null,
-        };
-      } else if (recoveryRequired) {
-        nextState = { error: errorString, errorInfo, isTracking: true, isRecoveryRequired: true };
-      } else {
-        nextState = { error: errorString, errorInfo };
-      }
-
-      useAsleepStore.setState(nextState);
-      addLog(`[onTrackingError] error: ${errorString}`);
-    },
-    // Connected: iOS didInterrupt, Android NOT IMPLEMENTED
-    onTrackingInterrupted: () => {
-      setIsTrackingPaused(true);
-      addLog(`[onTrackingInterrupted]`);
-    },
-    // Connected: iOS didResume, Android NOT IMPLEMENTED
-    // Always clear the error: some iOS recovery paths (e.g. cannotActivateInBackground
-    // retry) reach this handler without a preceding didInterrupt, and the stale error
-    // should still be cleared. Only the paused-state mutation is gated, to dedup the
-    // iOS 3.2.1+ double fire from handleRecovering -> handleResumed.
-    // isRecoveryRequired, not isTrackingPaused, is authoritative when recording is
-    // dead because didResume fires before the engine restart is attempted.
-    onTrackingResumed: () => {
-      const wasPaused = useAsleepStore.getState().isTrackingPaused;
-      useAsleepStore.setState(
-        wasPaused ? { error: null, errorInfo: null, isTrackingPaused: false } : { error: null, errorInfo: null },
-      );
-      addLog(wasPaused ? `[onTrackingResumed]` : `[onTrackingResumed] (no prior pause; error cleared)`);
-    },
-    // Connected: iOS micPermissionWasDenied, Android NOT IMPLEMENTED
-    onMicPermissionDenied: () => {
-      addLog(`[onMicPermissionDenied]`);
-    },
-    // Connected: iOS AsleepLogger callbacks, Android sendEvent called directly
-    onDebugLog: (data: any) => {
-      addLog(`[onDebugLog] message: ${data.message}`);
-    },
-    // Connected: iOS setupDidComplete, Android onComplete (AsleepSetupListener)
-    onSetupDidComplete: () => {
-      useAsleepStore.setState({ isSetupInProgress: false, isSetupComplete: true });
-      addLog(`[onSetupDidComplete]`);
-    },
-    // Connected: iOS setupDidFail, Android onFail (AsleepSetupListener)
-    onSetupDidFail: (data: any) => {
-      const errorString = JSON.stringify(data);
-      useAsleepStore.setState({
-        error: errorString,
-        errorInfo: null,
-        isSetupInProgress: false,
-        isSetupComplete: false,
-      });
-      addLog(`[onSetupDidFail] error: ${errorString}`);
-    },
-    // Connected: iOS setupInProgress, Android onProgress (AsleepSetupListener)
-    onSetupInProgress: (data: any) => {
-      setIsSetupInProgress(true);
-      addLog(`[onSetupInProgress] progress: ${data.progress}%`);
-    },
-    // Connected: iOS analyzing (session), Android onSleepDataReceived (AsleepSleepDataListener)
-    // Android serializes snake_case; normalize so both platforms match AsleepAnalysisResult.
-    onAnalysisResult: (data: any) => {
-      const normalized = convertKeysToCamelCase(data);
-      useAsleepStore.setState({ analysisResult: normalized, isAnalyzing: false });
-      if (useAsleepStore.getState().showDebugLog) {
-        addLog(`[onAnalysisResult] ${JSON.stringify(normalized)}`);
-      }
-    },
-  };
-
-  // register all event listeners
-  const subscriptions: (() => void)[] = [];
-  Object.entries(handlers).forEach(([eventType, handler]) => {
-    const subscription = emitter.addListener(eventType, handler);
-    subscriptions.push(() => subscription.remove());
-  });
+  const eventTypes: EventName[] = [
+    "onUserJoined",
+    "onUserJoinFailed",
+    "onUserDeleted",
+    "onTrackingCreated",
+    "onTrackingUploaded",
+    "onTrackingClosed",
+    "onTrackingFailed",
+    "onTrackingInterrupted",
+    "onTrackingResumed",
+    "onMicPermissionDenied",
+    "onDebugLog",
+    "onSetupDidComplete",
+    "onSetupDidFail",
+    "onSetupInProgress",
+    "onAnalysisResult",
+  ];
+  const subscriptions = eventTypes.map((eventType) =>
+    emitter.addListener(eventType, (payload: unknown) => applyEvent(eventType, payload)),
+  );
 
   refCount++;
   teardown = () => {
-    subscriptions.forEach((unsubscribe) => unsubscribe());
+    subscriptions.forEach((subscription) => subscription.remove());
     teardown = null;
   };
-
   return makeCleanup();
 };
 
 const makeCleanup = (): (() => void) => {
-  // Idempotent per-caller cleanup. The `called` flag is closure-private so
-  // calling the returned function twice (e.g. Strict Mode double-effect)
-  // decrements the shared ref count only once.
   let called = false;
   return () => {
     if (called) return;

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -281,11 +281,9 @@ export const asleepActions: AsleepActions = {
     if (state.setupStatus === "inProgress") {
       return storeAndThrow(new AsleepError("OPERATION_IN_PROGRESS", "Setup is already in progress."));
     }
-    if (state.trackingStatus !== "idle") {
-      return storeAndThrow(
-        new AsleepError("INVALID_STATE", "Cannot initialize configuration while tracking is in progress."),
-      );
-    }
+    // No tracking-state guard here: checkAndRestoreTracking() reconnects a live
+    // session before the app configures the SDK, so this must remain callable
+    // while trackingStatus is "tracking" (v1 behavior the restore flow relies on).
     const errorBefore = state.error;
     addLog("[initAsleepConfig] Start");
     useAsleepStore.setState({ setupStatus: "inProgress" });
@@ -450,7 +448,11 @@ export const asleepActions: AsleepActions = {
   getReport: async (sessionId) => {
     const errorBefore = useAsleepStore.getState().error;
     try {
-      const report = normalizeReport(await AsleepModule.getReport(sessionId), sessionId);
+      const payload = await AsleepModule.getReport(sessionId);
+      if (payload == null) {
+        throw new AsleepError("REPORT_NOT_FOUND", `No report available for session "${sessionId}".`);
+      }
+      const report = normalizeReport(payload, sessionId);
       clearErrorIfUnchanged(errorBefore);
       return report;
     } catch (error) {
@@ -461,7 +463,7 @@ export const asleepActions: AsleepActions = {
   getReportList: async (fromDate, toDate) => {
     const errorBefore = useAsleepStore.getState().error;
     try {
-      const reportList = await AsleepModule.getReportList(fromDate, toDate);
+      const reportList = (await AsleepModule.getReportList(fromDate, toDate)) ?? [];
       const result = reportList.map((session: any) => {
         const converted = convertKeysToCamelCase(session);
         return {
@@ -485,7 +487,11 @@ export const asleepActions: AsleepActions = {
   getAverageReport: async (fromDate, toDate) => {
     const errorBefore = useAsleepStore.getState().error;
     try {
-      const result = convertKeysToCamelCase(await AsleepModule.getAverageReport(fromDate, toDate));
+      const payload = await AsleepModule.getAverageReport(fromDate, toDate);
+      if (payload == null) {
+        throw new AsleepError("REPORT_NOT_FOUND", `No average report available for ${fromDate} to ${toDate}.`);
+      }
+      const result = convertKeysToCamelCase(payload);
       clearErrorIfUnchanged(errorBefore);
       return result;
     } catch (error) {

--- a/src/AsleepStore.ts
+++ b/src/AsleepStore.ts
@@ -381,11 +381,12 @@ export const asleepActions: AsleepActions = {
     const errorBefore = state.error;
     try {
       if (!(await asleepActions.hasRequiredPermissions())) {
-        const message =
-          Platform.OS === "android" && Platform.Version >= 33
-            ? "Microphone and notification permissions are required. Call requestRequiredPermissions() before startTracking()."
-            : "Microphone permission is required. Call requestRequiredPermissions() before startTracking().";
-        storeAndThrow(new AsleepError("PERMISSION_DENIED", message));
+        storeAndThrow(
+          new AsleepError(
+            "PERMISSION_DENIED",
+            "Microphone permission is required. Call requestRequiredPermissions() before startTracking().",
+          ),
+        );
       }
 
       if (Platform.OS === "android" && !(await AsleepModule.isBatteryOptimizationExempted())) {
@@ -532,14 +533,13 @@ export const asleepActions: AsleepActions = {
         const permissions = [PermissionsAndroid.PERMISSIONS.RECORD_AUDIO];
         if (Platform.Version >= 33) permissions.push(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
         const results = await PermissionsAndroid.requestMultiple(permissions);
+        // POST_NOTIFICATIONS is requested for foreground-service notification
+        // visibility but is not needed for tracking to run, so the returned
+        // boolean mirrors hasRequiredPermissions(): microphone-side grants only.
         const audioGranted =
           results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED;
-        const notificationGranted =
-          Platform.Version >= 33
-            ? results[PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS] === PermissionsAndroid.RESULTS.GRANTED
-            : true;
         clearErrorIfUnchanged(errorBefore);
-        return audioGranted && notificationGranted;
+        return audioGranted;
       }
       const result = await AsleepModule.requestRequiredPermissions();
       clearErrorIfUnchanged(errorBefore);

--- a/src/__tests__/Asleep.types.test.ts
+++ b/src/__tests__/Asleep.types.test.ts
@@ -1,4 +1,4 @@
-import { TrackingConfig, AudioSessionOption, AsleepErrorInfo, AsleepEventType } from "../Asleep.types";
+import { TrackingConfig, AudioSessionOption, AsleepEventType } from "../Asleep.types";
 
 describe("TrackingConfig", () => {
   it("accepts android-only config", () => {
@@ -114,29 +114,6 @@ describe("onTrackingFailed event payload", () => {
     };
     expect(payload.sdkCode).toBe(11000);
     expect(payload.errorCode).toBe(39);
-  });
-});
-
-describe("AsleepErrorInfo", () => {
-  it("pairs a category with the code and optional native fields", () => {
-    const info: AsleepErrorInfo = {
-      code: "TRACKING_FAILED",
-      category: "transient",
-      sdkCode: 23000,
-      message: "Failed to upload",
-    };
-    expect(info.category).toBe("transient");
-    expect(info.sdkCode).toBe(23000);
-  });
-
-  it("supports the minimal unknown shape", () => {
-    const info: AsleepErrorInfo = {
-      code: "UNKNOWN_ERROR",
-      category: "unknown",
-      caseName: "httpStatus(500, ...)",
-    };
-    expect(info.category).toBe("unknown");
-    expect(info.sdkCode).toBeUndefined();
   });
 });
 

--- a/src/__tests__/AsleepError.test.ts
+++ b/src/__tests__/AsleepError.test.ts
@@ -1,0 +1,65 @@
+import { AsleepError } from "../Asleep.types";
+
+describe("AsleepError", () => {
+  it("extends Error with a stable code and prototype identity", () => {
+    const error = new AsleepError("INVALID_STATE", "Tracking is already active.");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AsleepError);
+    expect(error.name).toBe("AsleepError");
+    expect(error.code).toBe("INVALID_STATE");
+    expect(error.message).toBe("Tracking is already active.");
+  });
+
+  it("preserves classification metadata and the original cause", () => {
+    const cause = {
+      code: "TRACKING_FAILED",
+      sdkCode: 11003,
+      caseName: "audioInitializationFailed",
+    };
+    const error = new AsleepError("TRACKING_FAILED", "Audio initialization failed.", {
+      cause,
+      category: "recordingDead",
+      sdkCode: 11003,
+      caseName: "audioInitializationFailed",
+    });
+
+    expect(error.category).toBe("recordingDead");
+    expect(error.sdkCode).toBe(11003);
+    expect(error.caseName).toBe("audioInitializationFailed");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("leaves optional metadata undefined when it is not supplied", () => {
+    const error = new AsleepError("UNKNOWN_ERROR", "Unknown error");
+
+    expect(error.category).toBeUndefined();
+    expect(error.sdkCode).toBeUndefined();
+    expect(error.caseName).toBeUndefined();
+    expect(error.cause).toBeUndefined();
+  });
+
+  it("is throwable and retains its identity in a catch clause", () => {
+    expect(() => {
+      throw new AsleepError("BOOM", "fell over");
+    }).toThrow("fell over");
+
+    try {
+      throw new AsleepError("BOOM", "fell over");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AsleepError);
+      if (error instanceof AsleepError) {
+        expect(error.code).toBe("BOOM");
+      }
+    }
+  });
+
+  it("supports subclassing under transpilation-compatible prototype repair", () => {
+    class SpecializedAsleepError extends AsleepError {}
+
+    const error = new SpecializedAsleepError("SPECIAL", "specialized");
+
+    expect(error).toBeInstanceOf(SpecializedAsleepError);
+    expect(error).toBeInstanceOf(AsleepError);
+  });
+});

--- a/src/__tests__/AsleepStore.smoke.test.ts
+++ b/src/__tests__/AsleepStore.smoke.test.ts
@@ -1,0 +1,38 @@
+import { createMockAsleepModule, createMockEventEmitter } from "./_helpers/factories.test";
+
+const mockModule = createMockAsleepModule();
+const mockEmitter = createMockEventEmitter();
+
+jest.mock("../AsleepModule", () => ({ __esModule: true, default: mockModule }));
+jest.mock("expo-modules-core", () => ({
+  EventEmitter: jest.fn().mockImplementation(() => mockEmitter),
+  requireNativeModule: jest.fn(() => mockModule),
+}));
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios", Version: 17 },
+  PermissionsAndroid: {
+    PERMISSIONS: { RECORD_AUDIO: "RECORD_AUDIO", POST_NOTIFICATIONS: "POST_NOTIFICATIONS" },
+    RESULTS: { GRANTED: "granted" },
+    requestMultiple: jest.fn().mockResolvedValue({ RECORD_AUDIO: "granted" }),
+  },
+}));
+
+describe("AsleepStore mock harness", () => {
+  it("imports the facts store and stable actions", () => {
+    const store = require("../AsleepStore");
+    expect(store.useAsleepStore).toBeDefined();
+    expect(store.asleepActions).toBeDefined();
+    expect(store.initializeAsleepListeners).toBeDefined();
+  });
+
+  it("projects the expected public defaults", () => {
+    const { toPublicState, useAsleepStore } = require("../AsleepStore");
+    expect(toPublicState(useAsleepStore.getState())).toMatchObject({
+      status: "idle",
+      isTracking: false,
+      error: null,
+      userId: null,
+      sessionId: null,
+    });
+  });
+});

--- a/src/__tests__/AsleepStore.test.ts
+++ b/src/__tests__/AsleepStore.test.ts
@@ -1,15 +1,3 @@
-/**
- * Tests for the v1.0.18 patch — non-breaking fixes applied on top of the
- * zustand-backed store.
- *
- * Locks in:
- * - Ref-counted initializeAsleepListeners (multi-mount safety)
- * - addLog gated on showDebugLog (default is zero-cost)
- * - Batched event handler setStates (one notification per native event)
- * - Success path error clear (no stale failure messages)
- * - console.error spy guard (regression prevention)
- * - __DEV__ gate on warnings
- */
 import type { MockAsleepModule, MockEventEmitter } from "./_helpers/factories.test";
 
 let mockModule: MockAsleepModule;
@@ -30,734 +18,359 @@ jest.mock("expo-modules-core", () => {
   };
 });
 
-jest.mock("react-native", () => {
-  const platform = { OS: "ios" as "ios" | "android", Version: 17 as number };
-  return {
-    Platform: platform,
-    PermissionsAndroid: {
-      PERMISSIONS: { RECORD_AUDIO: "RECORD_AUDIO", POST_NOTIFICATIONS: "POST_NOTIFICATIONS" },
-      RESULTS: { GRANTED: "granted", DENIED: "denied", NEVER_ASK_AGAIN: "never_ask_again" },
-      requestMultiple: jest.fn().mockResolvedValue({
-        RECORD_AUDIO: "granted",
-        POST_NOTIFICATIONS: "granted",
-      }),
-    },
-  };
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios", Version: 17 },
+  PermissionsAndroid: {
+    PERMISSIONS: { RECORD_AUDIO: "RECORD_AUDIO", POST_NOTIFICATIONS: "POST_NOTIFICATIONS" },
+    RESULTS: { GRANTED: "granted", DENIED: "denied", NEVER_ASK_AGAIN: "never_ask_again" },
+    requestMultiple: jest.fn().mockResolvedValue({ RECORD_AUDIO: "granted", POST_NOTIFICATIONS: "granted" }),
+  },
+}));
+
+import { AsleepError } from "../Asleep.types";
+import {
+  asleepActions,
+  initializeAsleepListeners,
+  normalizeError,
+  toPublicState,
+  useAsleepStore,
+  type InternalAsleepState,
+} from "../AsleepStore";
+import { setMockPlatform } from "./_helpers/factories.test";
+
+const initialState = useAsleepStore.getState();
+let cleanup: () => void;
+
+const resetState = (partial: Partial<InternalAsleepState> = {}) => {
+  useAsleepStore.setState({
+    ...initialState,
+    setupStatus: "idle",
+    trackingStatus: "idle",
+    sessionId: null,
+    userId: null,
+    error: null,
+    analysisResult: null,
+    isAnalyzing: false,
+    didClose: false,
+    isODAEnabled: false,
+    trackingStartTime: null,
+    isInitialized: false,
+    hasCheckedStatus: false,
+    hasCheckedBatteryOptimization: false,
+    showDebugLog: false,
+    log: "",
+    ...partial,
+  });
+};
+
+beforeAll(() => {
+  cleanup = initializeAsleepListeners();
 });
 
-import { useAsleepStore, initializeAsleepListeners } from "../AsleepStore";
+afterAll(() => cleanup());
 
-const setPlatform = (os: "ios" | "android", version = 33) => {
-  const rn = require("react-native");
-  rn.Platform.OS = os;
-  rn.Platform.Version = version;
-};
-
-const captureInitial = () => {
-  const s = useAsleepStore.getState();
-  return {
-    didClose: s.didClose,
-    isTracking: s.isTracking,
-    isTrackingPaused: s.isTrackingPaused,
-    isRecoveryRequired: s.isRecoveryRequired,
-    error: s.error,
-    errorInfo: s.errorInfo,
-    userId: s.userId,
-    sessionId: s.sessionId,
-    showDebugLog: s.showDebugLog,
-    log: s.log,
-    analysisResult: s.analysisResult,
-    isODAEnabled: s.isODAEnabled,
-    isAnalyzing: s.isAnalyzing,
-    trackingStartTime: s.trackingStartTime,
-    isInitialized: s.isInitialized,
-    isSetupInProgress: s.isSetupInProgress,
-    isSetupComplete: s.isSetupComplete,
-    hasCheckedStatus: s.hasCheckedStatus,
-    hasCheckedBatteryOptimization: s.hasCheckedBatteryOptimization,
-  };
-};
-
-const INITIAL = captureInitial();
-
-const resetStore = () => {
-  useAsleepStore.setState({ ...INITIAL });
-  jest.clearAllMocks();
-  setPlatform("ios", 17);
-};
-
-// Library-boundary guard: the store must never bypass consumer observability
-// by writing to console.error. Any test that triggers it is a regression.
-let consoleErrorSpy: jest.SpyInstance;
 beforeEach(() => {
-  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-});
-afterEach(() => {
-  expect(consoleErrorSpy).not.toHaveBeenCalled();
-  consoleErrorSpy.mockRestore();
+  jest.clearAllMocks();
+  setMockPlatform({ OS: "ios", Version: 17 });
+  resetState();
 });
 
-describe("initializeAsleepListeners ref counting", () => {
-  // The module-private refCount is not directly readable from tests, so we
-  // track every cleanup we create and drain them in afterEach. This keeps
-  // refCount at 0 between tests even if an assertion failure short-circuits
-  // an earlier test before its own cleanup call.
-  const cleanups: (() => void)[] = [];
-  const trackedInit = () => {
-    const c = initializeAsleepListeners();
-    cleanups.push(c);
-    return c;
-  };
-
-  beforeEach(resetStore);
-  afterEach(() => {
-    while (cleanups.length) cleanups.pop()!();
+describe("error normalization", () => {
+  it("preserves native metadata without stringifying the payload", () => {
+    const payload = { code: "NATIVE", detail: "failed", sdkCode: 22000, caseName: "create" };
+    const error = normalizeError(payload, "FALLBACK");
+    expect(error).toBeInstanceOf(AsleepError);
+    expect(error).toMatchObject({
+      code: "NATIVE",
+      message: "failed",
+      sdkCode: 22000,
+      caseName: "create",
+      cause: payload,
+    });
   });
 
-  it("first cleanup does not detach listeners while another holder is active", () => {
-    const cleanupA = trackedInit();
-    trackedInit(); // cleanupB
-    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBeGreaterThan(0);
-
-    cleanupA();
-    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBeGreaterThan(0);
-  });
-
-  it("calling the same cleanup twice is a no-op", () => {
-    const cleanupA = trackedInit();
-    trackedInit(); // cleanupB
-    cleanupA();
-    cleanupA();
-    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBeGreaterThan(0);
-  });
-
-  it("re-initializes cleanly after final teardown", () => {
-    const cleanup1 = trackedInit();
-    cleanup1();
-    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBe(0);
-
-    trackedInit();
-    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBeGreaterThan(0);
+  it("returns an existing AsleepError unchanged when no overrides are supplied", () => {
+    const error = new AsleepError("EXISTING", "message");
+    expect(normalizeError(error, "FALLBACK")).toBe(error);
   });
 });
 
-describe("notification batching (one setState per native event)", () => {
-  let cleanup: (() => void) | null = null;
-
-  beforeEach(() => {
-    resetStore();
-    cleanup = initializeAsleepListeners();
+describe("public projection", () => {
+  it.each([
+    ["idle", false, false, false],
+    ["tracking", true, false, false],
+    ["paused", true, true, false],
+    ["recoveryRequired", true, false, true],
+  ] as const)("derives %s consistently", (status, isTracking, isTrackingPaused, isRecoveryRequired) => {
+    resetState({ trackingStatus: status });
+    expect(toPublicState(useAsleepStore.getState())).toMatchObject({
+      status,
+      isTracking,
+      isTrackingPaused,
+      isRecoveryRequired,
+    });
   });
 
-  afterEach(() => {
-    cleanup?.();
-    cleanup = null;
+  it("derives setup booleans and hides internal flags", () => {
+    resetState({ setupStatus: "inProgress", hasCheckedStatus: true, showDebugLog: true });
+    const state = toPublicState(useAsleepStore.getState());
+    expect(state.isSetupInProgress).toBe(true);
+    expect(state.isSetupComplete).toBe(false);
+    expect(state).not.toHaveProperty("hasCheckedStatus");
+    expect(state).not.toHaveProperty("showDebugLog");
+    expect(state).not.toHaveProperty("trackingStartTime");
   });
 
-  // With enableLog(false) (the default), addLog is a no-op for state.
-  // Every batched handler produces exactly ONE subscriber notification.
-  const expectSingleNotificationFor = (event: string, payload: unknown, setup?: () => void) => {
-    setup?.();
+  it("caches the projection for the same internal reference", () => {
+    const internal = useAsleepStore.getState();
+    expect(toPublicState(internal)).toBe(toPublicState(internal));
+  });
+});
+
+describe("listener lifecycle", () => {
+  it("attaches one native listener set for multiple holders", () => {
+    const extraA = initializeAsleepListeners();
+    const extraB = initializeAsleepListeners();
+    expect(mockEmitter.addListener).not.toHaveBeenCalled();
+    extraA();
+    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBe(1);
+    extraB();
+    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBe(1);
+  });
+
+  it("caller cleanup is idempotent", () => {
+    const extra = initializeAsleepListeners();
+    extra();
+    extra();
+    expect(mockEmitter.__listenerCount("onTrackingCreated")).toBe(1);
+  });
+});
+
+describe("one reducer transaction per native event", () => {
+  const cases: Array<[string, unknown, Partial<InternalAsleepState>]> = [
+    ["onUserJoined", { userId: "user" }, {}],
+    ["onUserJoinFailed", { detail: "join failed", sdkCode: 10000 }, {}],
+    ["onUserDeleted", { userId: "user" }, { userId: "old" }],
+    ["onTrackingCreated", { sessionId: "session" }, {}],
+    ["onTrackingUploaded", { sequence: 2 }, { trackingStatus: "tracking" }],
+    ["onTrackingClosed", { sessionId: "session" }, { trackingStatus: "tracking" }],
+    ["onTrackingFailed", { code: "TRACKING_FAILED", error: "failed", sdkCode: 23000 }, { trackingStatus: "tracking" }],
+    ["onTrackingInterrupted", undefined, { trackingStatus: "tracking" }],
+    ["onTrackingResumed", undefined, { trackingStatus: "paused", error: new AsleepError("OLD", "old") }],
+    ["onMicPermissionDenied", undefined, {}],
+    ["onDebugLog", { message: "native" }, {}],
+    ["onSetupDidComplete", undefined, { setupStatus: "inProgress" }],
+    ["onSetupDidFail", { error: "setup failed", sdkCode: 10000 }, { setupStatus: "inProgress" }],
+    ["onSetupInProgress", { progress: 50 }, {}],
+    ["onAnalysisResult", { sleep_stages: [1, 2] }, { isAnalyzing: true }],
+  ];
+
+  it.each(cases)("%s emits exactly once with debug logging enabled", async (event, payload, setup) => {
+    resetState({ ...setup, showDebugLog: true });
     const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
+    const unsubscribe = useAsleepStore.subscribe(listener);
     mockEmitter.__emit(event, payload);
-    off();
+    await Promise.resolve();
+    unsubscribe();
     expect(listener).toHaveBeenCalledTimes(1);
-  };
-
-  it("onTrackingCreated → single notification", () => {
-    expectSingleNotificationFor("onTrackingCreated", { sessionId: "sess-1" });
   });
 
-  it("onTrackingClosed → single notification", () => {
-    expectSingleNotificationFor("onTrackingClosed", { sessionId: "final" }, () => {
-      useAsleepStore.setState({ isTracking: true, isAnalyzing: true, trackingStartTime: new Date() });
-    });
-  });
-
-  it("onTrackingFailed (terminal) → single notification", () => {
-    expectSingleNotificationFor("onTrackingFailed", { code: "UPLOAD_TRACKING_TERMINATED", error: "x" }, () => {
-      useAsleepStore.setState({ isTracking: true });
-    });
-  });
-
-  it("onTrackingResumed (was paused) → single notification", () => {
-    expectSingleNotificationFor("onTrackingResumed", undefined, () => {
-      useAsleepStore.setState({ isTrackingPaused: true, error: "stale" });
-    });
-  });
-
-  it("onSetupDidComplete → single notification", () => {
-    expectSingleNotificationFor("onSetupDidComplete", undefined);
-  });
-
-  it("onSetupDidFail → single notification", () => {
-    expectSingleNotificationFor("onSetupDidFail", { error: "boom" });
-  });
-
-  it("onAnalysisResult → single notification", () => {
-    expectSingleNotificationFor("onAnalysisResult", { id: "a", state: "ANALYZING" }, () => {
-      useAsleepStore.setState({ isAnalyzing: true });
-    });
-  });
-
-  it("onMicPermissionDenied → zero notifications (no state change with log gated)", () => {
+  it("no-op events emit zero times with debug logging disabled", () => {
     const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
+    const unsubscribe = useAsleepStore.subscribe(listener);
     mockEmitter.__emit("onMicPermissionDenied", undefined);
-    off();
+    mockEmitter.__emit("onDebugLog", { message: "ignored" });
+    unsubscribe();
     expect(listener).not.toHaveBeenCalled();
   });
 
-  it("onTrackingUploaded triggers the native analysis call exactly once per ODA upload", () => {
-    // The store action requestAnalysis wraps mockModule.requestAnalysis. Counting
-    // the native call locks in that the handler no longer pre-flips isAnalyzing
-    // separately and then redundantly invokes requestAnalysis (which also flips it).
-    useAsleepStore.setState({ isODAEnabled: true, isTracking: true });
-    mockModule.requestAnalysis.mockClear();
-    mockEmitter.__emit("onTrackingUploaded", { sequence: 1 });
-    expect(mockModule.requestAnalysis).toHaveBeenCalledTimes(1);
+  it("normalizes Android analysis casing", () => {
+    mockEmitter.__emit("onAnalysisResult", { sleep_stages: [1], start_time: "now" });
+    expect(useAsleepStore.getState().analysisResult).toEqual({ sleepStages: [1], startTime: "now" });
   });
+});
 
-  it("onTrackingUploaded triggers analysis on non-ODA modulo cadence (sequence 11, 21, …)", () => {
-    // Non-ODA path: analysis fires when sequence >= 10 and sequence % 10 === 1.
-    // Lock the modulo so a future rebase cannot quietly drop the cadence.
-    useAsleepStore.setState({ isODAEnabled: false, isTracking: true });
-    mockModule.requestAnalysis.mockClear();
+describe("tracking failure classification", () => {
+  beforeEach(() => resetState({ trackingStatus: "tracking", isAnalyzing: true, trackingStartTime: new Date() }));
 
-    mockEmitter.__emit("onTrackingUploaded", { sequence: 11 });
-    expect(mockModule.requestAnalysis).toHaveBeenCalledTimes(1);
-
-    mockEmitter.__emit("onTrackingUploaded", { sequence: 12 });
-    expect(mockModule.requestAnalysis).toHaveBeenCalledTimes(1); // no trigger off-cadence
-
-    mockEmitter.__emit("onTrackingUploaded", { sequence: 21 });
-    expect(mockModule.requestAnalysis).toHaveBeenCalledTimes(2);
-  });
-
-  it("onTrackingFailed with a non-terminal code preserves isTracking and only stores the error", () => {
-    useAsleepStore.setState({ isTracking: true, isAnalyzing: true });
-    mockEmitter.__emit("onTrackingFailed", { code: "RECOVERABLE_GLITCH", error: "minor" });
-    const s = useAsleepStore.getState();
-    expect(s.isTracking).toBe(true);
-    expect(s.isAnalyzing).toBe(true);
-    expect(s.error).toContain("minor");
-  });
-
-  it("AUDIO_INITIALIZATION_FAILED clears tracking but leaves the native session open", () => {
-    useAsleepStore.setState({
-      isTracking: true,
-      isAnalyzing: true,
-      didClose: false,
-      trackingStartTime: new Date(),
-    });
-    // Real iOS payload carries sdkCode 11003 — the same number is in the
-    // Android terminal set, so this test also locks in string-bucket precedence.
+  it("classifies recording-dead strings before the numeric terminal fallback", () => {
     mockEmitter.__emit("onTrackingFailed", {
       code: "AUDIO_INITIALIZATION_FAILED",
-      error: "audio failed",
+      message: "audio",
       sdkCode: 11003,
     });
-
-    const s = useAsleepStore.getState();
-    expect(s.isTracking).toBe(false);
-    expect(s.isAnalyzing).toBe(false);
-    expect(s.trackingStartTime).toBeNull();
-    expect(s.didClose).toBe(false);
+    const state = useAsleepStore.getState();
+    expect(state.error).toMatchObject({ category: "recordingDead", sdkCode: 11003 });
+    expect(state.trackingStatus).toBe("idle");
+    expect(state.didClose).toBe(false);
   });
 
-  it("CANNOT_ACTIVATE_IN_BACKGROUND keeps tracking active and requires recovery", () => {
-    useAsleepStore.setState({ isTracking: true, isRecoveryRequired: false });
+  it("classifies recovery-required failures and keeps the session live", () => {
     mockEmitter.__emit("onTrackingFailed", {
       code: "CANNOT_ACTIVATE_IN_BACKGROUND",
-      error: "background activation failed",
+      message: "background",
+      sdkCode: 11003,
     });
-
-    const s = useAsleepStore.getState();
-    expect(s.isTracking).toBe(true);
-    expect(s.isRecoveryRequired).toBe(true);
+    const state = useAsleepStore.getState();
+    expect(state.error?.category).toBe("recoveryRequired");
+    expect(state.trackingStatus).toBe("recoveryRequired");
+    expect(toPublicState(state).isTracking).toBe(true);
   });
 
-  it("marks recovery required when failure follows interrupted and resumed events", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingInterrupted", undefined);
+  it("classifies terminal string and numeric codes", () => {
+    mockEmitter.__emit("onTrackingFailed", {
+      code: "TRACKING_FAILED",
+      message: "terminal",
+      sdkCode: 22500,
+    });
+    expect(useAsleepStore.getState()).toMatchObject({
+      trackingStatus: "idle",
+      didClose: true,
+      isAnalyzing: false,
+    });
+    expect(useAsleepStore.getState().error?.category).toBe("terminal");
+  });
+
+  it("classifies survivable upload failures as transient without changing liveness", () => {
+    mockEmitter.__emit("onTrackingFailed", {
+      code: "TRACKING_FAILED",
+      message: "retry exhausted",
+      sdkCode: 23000,
+    });
+    expect(useAsleepStore.getState().error?.category).toBe("transient");
+    expect(useAsleepStore.getState().trackingStatus).toBe("tracking");
+  });
+
+  it("classifies unknown codes without changing liveness", () => {
+    mockEmitter.__emit("onTrackingFailed", { code: "NEW_CODE", message: "unknown", sdkCode: 34999 });
+    expect(useAsleepStore.getState().error?.category).toBe("unknown");
+    expect(useAsleepStore.getState().trackingStatus).toBe("tracking");
+  });
+
+  it("only a completed upload clears recovery-required state", () => {
+    resetState({
+      trackingStatus: "recoveryRequired",
+      error: new AsleepError("RECOVERY", "needed", { category: "recoveryRequired" }),
+    });
     mockEmitter.__emit("onTrackingResumed", undefined);
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "CANNOT_ACTIVATE_IN_BACKGROUND",
-      error: "background activation failed",
-    });
-
-    const s = useAsleepStore.getState();
-    expect(s.isTrackingPaused).toBe(false);
-    expect(s.isRecoveryRequired).toBe(true);
-  });
-
-  it("clears recovery required when the retry escalates to a terminal failure", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", { code: "CANNOT_ACTIVATE_IN_BACKGROUND", error: "background" });
-    expect(useAsleepStore.getState().isRecoveryRequired).toBe(true);
-
-    // iOS retries cannotActivateInBackground 3x, then gives up with
-    // interruptionRecoveryFailed. No upload will ever arrive to clear the flag.
-    mockEmitter.__emit("onTrackingFailed", { code: "INTERRUPTION_RECOVERY_FAILED", error: "gave up" });
-
-    const s = useAsleepStore.getState();
-    expect(s.isTracking).toBe(false);
-    expect(s.didClose).toBe(true);
-    expect(s.isRecoveryRequired).toBe(false);
-  });
-
-  it("clears recovery required when recording dies after a recovery attempt", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "CANNOT_ACTIVATE_IN_BACKGROUND",
-      error: "background",
-      sdkCode: 11000,
-    });
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "AUDIO_INITIALIZATION_FAILED",
-      error: "audio failed",
-      sdkCode: 11003,
-    });
-
-    const s = useAsleepStore.getState();
-    expect(s.isTracking).toBe(false);
-    expect(s.isRecoveryRequired).toBe(false);
-  });
-
-  it("clears recovery required after the next uploaded chunk", () => {
-    useAsleepStore.setState({ isTracking: true, isRecoveryRequired: true });
-    mockEmitter.__emit("onTrackingUploaded", { sequence: 1 });
-    expect(useAsleepStore.getState().isRecoveryRequired).toBe(false);
-  });
-
-  it("enableLog(true) opts log writes back in (+1 notify per event)", () => {
-    useAsleepStore.getState().enableLog(true);
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    mockEmitter.__emit("onMicPermissionDenied", undefined);
-    off();
-    expect(listener).toHaveBeenCalledTimes(1);
-    useAsleepStore.getState().enableLog(false);
+    expect(useAsleepStore.getState().trackingStatus).toBe("recoveryRequired");
+    expect(useAsleepStore.getState().error).toBeNull();
+    mockEmitter.__emit("onTrackingUploaded", { sequence: 2 });
+    expect(useAsleepStore.getState().trackingStatus).toBe("tracking");
   });
 });
 
-describe("errorInfo classification", () => {
-  let cleanup: (() => void) | null = null;
-
-  beforeEach(() => {
-    resetStore();
-    cleanup = initializeAsleepListeners();
+describe("action contracts", () => {
+  it("startTracking checks permission without requesting it", async () => {
+    resetState({ hasCheckedStatus: true, hasCheckedBatteryOptimization: true });
+    await asleepActions.startTracking();
+    expect(mockModule.hasRequiredPermissions).toHaveBeenCalledTimes(1);
+    expect(mockModule.requestRequiredPermissions).not.toHaveBeenCalled();
+    expect(mockModule.startTracking).toHaveBeenCalledTimes(1);
   });
 
-  afterEach(() => {
-    cleanup?.();
-    cleanup = null;
-  });
-
-  it("classifies terminal string codes and mirrors category into the error string", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", { code: "UPLOAD_TRACKING_TERMINATED", error: "x", sdkCode: 23499 });
-
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo).toEqual({ code: "UPLOAD_TRACKING_TERMINATED", category: "terminal", sdkCode: 23499 });
-    expect(JSON.parse(s.error!).category).toBe("terminal");
-  });
-
-  it("classifies Android terminal numeric codes and clears tracking state (regression: stuck isTracking)", () => {
-    // Android sends the generic "TRACKING_FAILED" string for terminal codes
-    // like 11003 (ERR_AUDIO). Before sdkCode classification these fell into the
-    // else bucket: isTracking stayed true forever because the native module
-    // suppresses the dual-fired onFinish for exactly these codes.
-    useAsleepStore.setState({ isTracking: true, isAnalyzing: true, trackingStartTime: new Date() });
-    mockEmitter.__emit("onTrackingFailed", { code: "TRACKING_FAILED", error: "audio dead", sdkCode: 11003 });
-
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo?.category).toBe("terminal");
-    expect(s.isTracking).toBe(false);
-    expect(s.isAnalyzing).toBe(false);
-    expect(s.didClose).toBe(true);
-    expect(s.trackingStartTime).toBeNull();
-  });
-
-  it("classifies recording-dead codes, letting the iOS string win over the numeric terminal set", () => {
-    // iOS sends sdkCode 11003 here; on Android the same number is session-terminal.
-    // The explicit string bucket must win: session is still open (didClose false).
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "AUDIO_INITIALIZATION_FAILED",
-      error: "audio failed",
-      sdkCode: 11003,
+  it("startTracking rejects denied permission with AsleepError", async () => {
+    resetState({ hasCheckedStatus: true, hasCheckedBatteryOptimization: true });
+    mockModule.hasRequiredPermissions.mockResolvedValueOnce(false);
+    await expect(asleepActions.startTracking()).rejects.toMatchObject({
+      name: "AsleepError",
+      code: "PERMISSION_DENIED",
     });
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo?.category).toBe("recordingDead");
-    expect(s.isTracking).toBe(false);
-    expect(s.didClose).toBe(false);
+    expect(mockModule.startTracking).not.toHaveBeenCalled();
   });
 
-  it("classifies recovery-required codes", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "CANNOT_ACTIVATE_IN_BACKGROUND",
-      error: "background",
-      sdkCode: 11000,
+  it("requestRequiredPermissions returns false for a normal Android denial", async () => {
+    setMockPlatform({ OS: "android", Version: 34 });
+    const { PermissionsAndroid } = require("react-native");
+    PermissionsAndroid.requestMultiple.mockResolvedValueOnce({
+      RECORD_AUDIO: "denied",
+      POST_NOTIFICATIONS: "granted",
     });
-    expect(useAsleepStore.getState().errorInfo?.category).toBe("recoveryRequired");
-  });
-
-  it("classifies survivable upload failures as transient and preserves tracking", () => {
-    useAsleepStore.setState({ isTracking: true, isAnalyzing: true });
-    mockEmitter.__emit("onTrackingFailed", { code: "TRACKING_FAILED", error: "upload blip", sdkCode: 23000 });
-
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo?.category).toBe("transient");
-    expect(s.isTracking).toBe(true);
-    expect(s.isAnalyzing).toBe(true);
-  });
-
-  it("falls back to unknown for unclassified codes and preserves tracking state", () => {
-    useAsleepStore.setState({ isTracking: true });
-    mockEmitter.__emit("onTrackingFailed", {
-      code: "UNKNOWN_ERROR",
-      error: "mystery",
-      caseName: "httpStatus(500, ...)",
-      sdkCode: 12345,
-    });
-
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo).toEqual({
-      code: "UNKNOWN_ERROR",
-      category: "unknown",
-      sdkCode: 12345,
-      caseName: "httpStatus(500, ...)",
-    });
-    expect(s.isTracking).toBe(true);
-  });
-
-  it("keeps the terminal state transition for terminal-by-sdkCode a single notification", () => {
-    useAsleepStore.setState({ isTracking: true });
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    mockEmitter.__emit("onTrackingFailed", { code: "TRACKING_FAILED", error: "x", sdkCode: 22500 });
-    off();
-    expect(listener).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("errorInfo lockstep with error", () => {
-  const staleInfo = { code: "TRACKING_FAILED", category: "transient" as const, sdkCode: 23000 };
-
-  let cleanup: (() => void) | null = null;
-
-  beforeEach(() => {
-    resetStore();
-    cleanup = initializeAsleepListeners();
-  });
-
-  afterEach(() => {
-    cleanup?.();
-    cleanup = null;
-  });
-
-  it("startTracking() clears errorInfo alongside error on success", async () => {
-    useAsleepStore.setState({
-      error: "stale",
-      errorInfo: staleInfo,
-      hasCheckedStatus: true,
-      hasCheckedBatteryOptimization: true,
-    });
-    await useAsleepStore.getState().startTracking();
-    const s = useAsleepStore.getState();
-    expect(s.error).toBeNull();
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("stopTracking() clears errorInfo alongside error on success", async () => {
-    useAsleepStore.setState({ error: "stale", errorInfo: staleInfo, isTracking: true });
-    await useAsleepStore.getState().stopTracking();
-    const s = useAsleepStore.getState();
-    expect(s.error).toBeNull();
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("non-lifecycle catches reset errorInfo so a previous event's category cannot linger", async () => {
-    useAsleepStore.setState({ errorInfo: staleInfo });
-    mockModule.requestAnalysis.mockRejectedValueOnce(new Error("analysis failed"));
-    await useAsleepStore.getState().requestAnalysis();
-
-    const s = useAsleepStore.getState();
-    expect(s.error).toBe("analysis failed");
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("stopTracking catch clears a stale verdict from an earlier failure", async () => {
-    useAsleepStore.setState({ errorInfo: staleInfo, isTracking: true });
-    mockModule.stopTracking.mockRejectedValueOnce(new Error("stop failed"));
-    await expect(useAsleepStore.getState().stopTracking()).rejects.toThrow("stop failed");
-
-    const s = useAsleepStore.getState();
-    expect(s.error).toBe("stop failed");
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("startTracking guard failure writes the new error even when a stale verdict exists", async () => {
-    // Guard throws happen before the pre-native clear; a verdict left by an
-    // earlier failure must not swallow the new error message.
-    useAsleepStore.setState({ errorInfo: staleInfo, error: "old", hasCheckedStatus: false });
-    await expect(useAsleepStore.getState().startTracking()).rejects.toThrow("checkAndRestoreTracking");
-
-    const s = useAsleepStore.getState();
-    expect(s.error).toContain("checkAndRestoreTracking");
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("startTracking rejection preserves a concurrently classified errorInfo", async () => {
-    // Android order: native fires the classified onTrackingFailed event first,
-    // then rejects the same start promise. The catch must not clobber the
-    // verdict with the raw rejection message.
-    useAsleepStore.setState({ hasCheckedStatus: true, hasCheckedBatteryOptimization: true });
-    let rejectStart!: (e: Error) => void;
-    const nativeCallReached = new Promise<void>((resolveReached) => {
-      mockModule.startTracking.mockImplementationOnce(() => {
-        resolveReached();
-        return new Promise((_, reject) => {
-          rejectStart = reject;
-        });
-      });
-    });
-    const startPromise = useAsleepStore.getState().startTracking();
-    // Wait until the action's pre-await setState has run (it precedes the
-    // native call), so the emitted event lands mid-await like on a device.
-    await nativeCallReached;
-    mockEmitter.__emit("onTrackingFailed", { code: "TRACKING_FAILED", error: "create failed", sdkCode: 22500 });
-    rejectStart!(new Error("Sleep tracking failed: 22500 - create failed"));
-    await expect(startPromise).rejects.toThrow("22500");
-
-    const s = useAsleepStore.getState();
-    expect(s.errorInfo).toEqual({ code: "TRACKING_FAILED", category: "terminal", sdkCode: 22500 });
-    expect(JSON.parse(s.error!).category).toBe("terminal");
-    expect(s.isTracking).toBe(false);
-    expect(s.trackingStartTime).toBeNull();
-  });
-
-  it("clearError() clears both fields", () => {
-    useAsleepStore.setState({ error: "stale", errorInfo: staleInfo });
-    useAsleepStore.getState().clearError();
-    const s = useAsleepStore.getState();
-    expect(s.error).toBeNull();
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("onTrackingResumed clears both fields", () => {
-    useAsleepStore.setState({ error: "stale", errorInfo: staleInfo, isTrackingPaused: true });
-    mockEmitter.__emit("onTrackingResumed", undefined);
-    const s = useAsleepStore.getState();
-    expect(s.error).toBeNull();
-    expect(s.errorInfo).toBeNull();
-  });
-
-  it("getReport() success clears errorInfo together with the guarded error clear", async () => {
-    useAsleepStore.setState({ error: "stale", errorInfo: staleInfo });
-    mockModule.getReport.mockResolvedValueOnce({ timezone: "", session: {} });
-    await useAsleepStore.getState().getReport("a");
-    const s = useAsleepStore.getState();
-    expect(s.error).toBeNull();
-    expect(s.errorInfo).toBeNull();
-  });
-});
-
-describe("resumeTracking platform support", () => {
-  beforeEach(resetStore);
-
-  it("rejects on Android with a typed unsupported-platform error", async () => {
-    setPlatform("android");
-    await expect(useAsleepStore.getState().resumeTracking()).rejects.toMatchObject({
-      name: "AsleepPlatformError",
-      code: "UNSUPPORTED_PLATFORM",
-      message: "resumeTracking is only supported on iOS.",
-    });
-  });
-});
-
-describe("success error clear is guarded — no spurious notifications", () => {
-  beforeEach(resetStore);
-
-  it("getReport success does NOT notify subscribers when error was already null", async () => {
-    mockModule.getReport.mockResolvedValueOnce({ timezone: "", session: {} });
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    await useAsleepStore.getState().getReport("a");
-    off();
-    expect(listener).not.toHaveBeenCalled();
-  });
-
-  it("getReportList success is silent when error was already null", async () => {
-    mockModule.getReportList.mockResolvedValueOnce([]);
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    await useAsleepStore.getState().getReportList("a", "b");
-    off();
-    expect(listener).not.toHaveBeenCalled();
-  });
-
-  it("getReport success DOES notify exactly once when there was a stale error", async () => {
-    useAsleepStore.setState({ error: "stale" });
-    mockModule.getReport.mockResolvedValueOnce({ timezone: "", session: {} });
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    await useAsleepStore.getState().getReport("a");
-    off();
-    expect(listener).toHaveBeenCalledTimes(1);
+    await expect(asleepActions.requestRequiredPermissions()).resolves.toBe(false);
     expect(useAsleepStore.getState().error).toBeNull();
   });
 
-  it("getReport success does NOT clobber an unrelated error that arrived during the await", async () => {
-    // Seed an initial state error (the snapshot the guard captures).
-    useAsleepStore.setState({ error: "old report error" });
-    // Resolve the native call only after we inject an interleaved error.
-    let resolveGet: (value: unknown) => void;
-    mockModule.getReport.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveGet = resolve;
+  it("requestRequiredPermissions normalizes a bridge failure", async () => {
+    mockModule.requestRequiredPermissions.mockRejectedValueOnce(new Error("bridge failed"));
+    await expect(asleepActions.requestRequiredPermissions()).rejects.toMatchObject({
+      code: "REQUEST_PERMISSION_FAILED",
+    });
+    expect(useAsleepStore.getState().error).toBeInstanceOf(AsleepError);
+  });
+
+  it("startTracking enforces restore and battery prerequisites", async () => {
+    await expect(asleepActions.startTracking()).rejects.toMatchObject({ code: "MISSING_PREREQUISITE" });
+    resetState({ hasCheckedStatus: true });
+    await expect(asleepActions.startTracking()).rejects.toMatchObject({ code: "MISSING_PREREQUISITE" });
+  });
+
+  it("resumeTracking rejects Android with a typed error", async () => {
+    setMockPlatform({ OS: "android", Version: 34 });
+    await expect(asleepActions.resumeTracking()).rejects.toMatchObject({ code: "UNSUPPORTED_PLATFORM" });
+  });
+
+  it.each([
+    ["getReport", () => asleepActions.getReport("session")],
+    ["getReportList", () => asleepActions.getReportList("2026-01-01", "2026-01-02")],
+    ["getAverageReport", () => asleepActions.getAverageReport("2026-01-01", "2026-01-02")],
+    ["deleteSession", () => asleepActions.deleteSession("session")],
+    ["requestAnalysis", () => asleepActions.requestAnalysis()],
+  ])("%s throws AsleepError rather than returning a sentinel", async (nativeName, call) => {
+    (mockModule as any)[nativeName].mockRejectedValueOnce(new Error("native failure"));
+    await expect(call()).rejects.toBeInstanceOf(AsleepError);
+  });
+
+  it("requestAnalysis return never writes analysisResult", async () => {
+    mockModule.requestAnalysis.mockResolvedValueOnce({ sleep_stages: [1] });
+    await expect(asleepActions.requestAnalysis()).resolves.toEqual({ sleepStages: [1] });
+    expect(useAsleepStore.getState().analysisResult).toBeNull();
+    expect(useAsleepStore.getState().isAnalyzing).toBe(true);
+  });
+
+  it("keeps a tracking failure emitted before lifecycle rejection", async () => {
+    resetState({ hasCheckedStatus: true, hasCheckedBatteryOptimization: true });
+    let rejectStart!: (error: Error) => void;
+    mockModule.startTracking.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectStart = reject;
       }),
     );
-    const getPromise = useAsleepStore.getState().getReport("a");
-    // Simulate a concurrent native failure landing while the await is in flight.
-    useAsleepStore.setState({ error: "tracking failed mid-flight" });
-    resolveGet!({ timezone: "", session: {} });
-    await getPromise;
-    // The capture-and-compare guard must leave the interleaved error untouched.
-    expect(useAsleepStore.getState().error).toBe("tracking failed mid-flight");
-  });
-});
-
-describe("success path clears stale error", () => {
-  beforeEach(resetStore);
-
-  it("setup() clears error on success", async () => {
-    useAsleepStore.setState({ error: "stale failure" });
-    await useAsleepStore.getState().setup({ apiKey: "k" });
-    expect(useAsleepStore.getState().error).toBeNull();
-  });
-
-  it("startTracking() clears error on success", async () => {
-    useAsleepStore.setState({
-      error: "stale",
-      hasCheckedStatus: true,
-      hasCheckedBatteryOptimization: true,
+    const promise = asleepActions.startTracking();
+    await Promise.resolve();
+    await Promise.resolve();
+    mockEmitter.__emit("onTrackingFailed", {
+      code: "TRACKING_FAILED",
+      message: "classified",
+      sdkCode: 22500,
     });
-    await useAsleepStore.getState().startTracking();
-    expect(useAsleepStore.getState().error).toBeNull();
+    const classified = useAsleepStore.getState().error;
+    rejectStart(new Error("raw rejection"));
+    await expect(promise).rejects.toBe(classified);
+    expect(useAsleepStore.getState().error).toBe(classified);
   });
 
-  it("stopTracking() clears error on success", async () => {
-    useAsleepStore.setState({ error: "stale", isTracking: true });
-    await useAsleepStore.getState().stopTracking();
-    expect(useAsleepStore.getState().error).toBeNull();
+  it("query success does not clobber an error emitted during the await", async () => {
+    const stale = new AsleepError("STALE", "stale");
+    resetState({ error: stale, trackingStatus: "tracking" });
+    let resolveReport!: (report: unknown) => void;
+    mockModule.getReport.mockReturnValueOnce(new Promise((resolve) => (resolveReport = resolve)));
+    const promise = asleepActions.getReport("session");
+    mockEmitter.__emit("onTrackingFailed", {
+      code: "TRACKING_FAILED",
+      message: "concurrent",
+      sdkCode: 23000,
+    });
+    const concurrent = useAsleepStore.getState().error;
+    resolveReport({ timezone: "UTC", session: { id: "session" }, missingDataRatio: 0, peculiarities: [] });
+    await promise;
+    expect(useAsleepStore.getState().error).toBe(concurrent);
   });
 
-  it("getReport() clears error on success", async () => {
-    useAsleepStore.setState({ error: "stale" });
-    mockModule.getReport.mockResolvedValueOnce({ timezone: "", session: {} });
-    await useAsleepStore.getState().getReport("a");
-    expect(useAsleepStore.getState().error).toBeNull();
-  });
-
-  it("getReportList() clears error on success", async () => {
-    useAsleepStore.setState({ error: "stale" });
-    mockModule.getReportList.mockResolvedValueOnce([]);
-    await useAsleepStore.getState().getReportList("from", "to");
-    expect(useAsleepStore.getState().error).toBeNull();
-  });
-});
-
-describe("addLog gating", () => {
-  beforeEach(resetStore);
-
-  it("forwards enableLog to the native logger on iOS", () => {
-    useAsleepStore.getState().enableLog(true);
-    expect(mockModule.enableLog).toHaveBeenCalledWith(true);
-
-    useAsleepStore.getState().enableLog(false);
-    expect(mockModule.enableLog).toHaveBeenLastCalledWith(false);
-  });
-
-  it("does not call the iOS logger bridge on Android", () => {
-    setPlatform("android");
-    useAsleepStore.getState().enableLog(true);
-    expect(mockModule.enableLog).not.toHaveBeenCalled();
-  });
-
-  it("does not write to state when showDebugLog is false (default)", () => {
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    useAsleepStore.getState().addLog("[test] hello");
-    off();
-    expect(listener).not.toHaveBeenCalled();
-    expect(useAsleepStore.getState().log).toBe("");
-  });
-
-  it("writes to state when enableLog(true) is set", () => {
-    useAsleepStore.getState().enableLog(true);
-    const listener = jest.fn();
-    const off = useAsleepStore.subscribe(listener);
-    useAsleepStore.getState().addLog("[test] hello");
-    off();
-    expect(listener).toHaveBeenCalled();
-    expect(useAsleepStore.getState().log).toContain("[test] hello");
-  });
-});
-
-describe("__DEV__ gated warnings", () => {
-  const setDev = (value: boolean) => {
-    (globalThis as { __DEV__?: boolean }).__DEV__ = value;
-  };
-
-  let warnSpy: jest.SpyInstance;
-  beforeEach(() => {
-    resetStore();
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-  });
-  afterEach(() => {
-    setDev(true);
-    warnSpy.mockRestore();
-  });
-
-  it("setCustomNotification on iOS warns in dev with [Asleep] prefix", async () => {
-    setPlatform("ios");
-    setDev(true);
-    await useAsleepStore.getState().setCustomNotification("t", "x");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[Asleep]"));
-  });
-
-  it("setCustomNotification on iOS is silent in production", async () => {
-    setPlatform("ios");
-    setDev(false);
-    await useAsleepStore.getState().setCustomNotification("t", "x");
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  it("query methods that silently return null/[] surface a dev-only warn", async () => {
-    setDev(true);
-    mockModule.getReport.mockRejectedValueOnce(new Error("net down"));
-    await useAsleepStore.getState().getReport("any");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("getReport failed"), expect.any(Error));
-  });
-
-  it("query method warn is silent in production", async () => {
-    setDev(false);
-    mockModule.getReport.mockRejectedValueOnce(new Error("net down"));
-    await useAsleepStore.getState().getReport("any");
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  it("requestMicrophonePermission deprecation is dev-gated", async () => {
-    setDev(false);
-    await useAsleepStore.getState().requestMicrophonePermission();
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    setDev(true);
-    await useAsleepStore.getState().requestMicrophonePermission();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("deprecated"));
+  it("never pairs console.error with thrown failures", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    mockModule.getReport.mockRejectedValueOnce(new Error("failure"));
+    await expect(asleepActions.getReport("session")).rejects.toBeInstanceOf(AsleepError);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/src/__tests__/AsleepStore.test.ts
+++ b/src/__tests__/AsleepStore.test.ts
@@ -290,6 +290,20 @@ describe("action contracts", () => {
     expect(useAsleepStore.getState().error).toBeNull();
   });
 
+  it("requestRequiredPermissions still requests notifications but does not require them", async () => {
+    setMockPlatform({ OS: "android", Version: 34 });
+    const { PermissionsAndroid } = require("react-native");
+    PermissionsAndroid.requestMultiple.mockResolvedValueOnce({
+      RECORD_AUDIO: "granted",
+      POST_NOTIFICATIONS: "denied",
+    });
+    await expect(asleepActions.requestRequiredPermissions()).resolves.toBe(true);
+    expect(PermissionsAndroid.requestMultiple).toHaveBeenLastCalledWith([
+      PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
+      PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+    ]);
+  });
+
   it("requestRequiredPermissions normalizes a bridge failure", async () => {
     mockModule.requestRequiredPermissions.mockRejectedValueOnce(new Error("bridge failed"));
     await expect(asleepActions.requestRequiredPermissions()).rejects.toMatchObject({

--- a/src/__tests__/AsleepStore.test.ts
+++ b/src/__tests__/AsleepStore.test.ts
@@ -304,6 +304,31 @@ describe("action contracts", () => {
     ]);
   });
 
+  it("initAsleepConfig stays callable while a restored session is tracking", async () => {
+    resetState({ trackingStatus: "tracking" });
+    await asleepActions.initAsleepConfig({ apiKey: "key" });
+    expect(mockModule.initAsleepConfig).toHaveBeenCalledTimes(1);
+    expect(useAsleepStore.getState().setupStatus).toBe("complete");
+  });
+
+  it("getReport throws REPORT_NOT_FOUND when native resolves no report", async () => {
+    mockModule.getReport.mockResolvedValueOnce(null);
+    await expect(asleepActions.getReport("session-1")).rejects.toMatchObject({ code: "REPORT_NOT_FOUND" });
+    expect(useAsleepStore.getState().error).toMatchObject({ code: "REPORT_NOT_FOUND" });
+  });
+
+  it("getAverageReport throws REPORT_NOT_FOUND when native resolves no report", async () => {
+    mockModule.getAverageReport.mockResolvedValueOnce(null);
+    await expect(asleepActions.getAverageReport("2026-07-01", "2026-07-07")).rejects.toMatchObject({
+      code: "REPORT_NOT_FOUND",
+    });
+  });
+
+  it("getReportList treats a null native payload as an empty list", async () => {
+    mockModule.getReportList.mockResolvedValueOnce(null);
+    await expect(asleepActions.getReportList("2026-07-01", "2026-07-07")).resolves.toEqual([]);
+  });
+
   it("requestRequiredPermissions normalizes a bridge failure", async () => {
     mockModule.requestRequiredPermissions.mockRejectedValueOnce(new Error("bridge failed"));
     await expect(asleepActions.requestRequiredPermissions()).rejects.toMatchObject({

--- a/src/__tests__/_helpers/factories.test.ts
+++ b/src/__tests__/_helpers/factories.test.ts
@@ -22,6 +22,7 @@ export type MockAsleepModule = {
   initAsleepConfig: jest.Mock;
   startTracking: jest.Mock;
   stopTracking: jest.Mock;
+  resumeTracking: jest.Mock;
   isTracking: jest.Mock;
   isSleepTrackingAlive: jest.Mock;
   connectSleepTracking: jest.Mock;
@@ -31,6 +32,7 @@ export type MockAsleepModule = {
   getReportList: jest.Mock;
   getAverageReport: jest.Mock;
   deleteSession: jest.Mock;
+  hasRequiredPermissions: jest.Mock;
   requestRequiredPermissions: jest.Mock;
   setCustomNotification: jest.Mock;
   enableLog: jest.Mock;
@@ -49,6 +51,7 @@ export const createMockAsleepModule = (): MockAsleepModule => ({
   initAsleepConfig: jest.fn().mockResolvedValue(undefined),
   startTracking: jest.fn().mockResolvedValue(undefined),
   stopTracking: jest.fn().mockResolvedValue("session-stub"),
+  resumeTracking: jest.fn().mockResolvedValue(undefined),
   isTracking: jest.fn().mockReturnValue(false),
   isSleepTrackingAlive: jest.fn().mockResolvedValue(false),
   connectSleepTracking: jest.fn().mockResolvedValue(false),
@@ -58,6 +61,7 @@ export const createMockAsleepModule = (): MockAsleepModule => ({
   getReportList: jest.fn().mockResolvedValue([]),
   getAverageReport: jest.fn().mockResolvedValue(null),
   deleteSession: jest.fn().mockResolvedValue(undefined),
+  hasRequiredPermissions: jest.fn().mockResolvedValue(true),
   requestRequiredPermissions: jest.fn().mockResolvedValue(true),
   setCustomNotification: jest.fn().mockResolvedValue(undefined),
   enableLog: jest.fn(),

--- a/src/__tests__/createStore.test.ts
+++ b/src/__tests__/createStore.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the vanilla store primitives. Covers the imperative surface
+ * (getState/setState/subscribe) and React hook caching behavior via
+ * react-test-renderer (we skip @testing-library because its react-test-renderer
+ * pin diverges from what's installed).
+ */
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { createStore } from "../store/createStore";
+
+type Counter = {
+  count: number;
+  label: string;
+  increment: () => void;
+};
+
+const makeCounter = () =>
+  createStore<Counter>((set) => ({
+    count: 0,
+    label: "init",
+    increment: () => set((s) => ({ count: s.count + 1 })),
+  }));
+
+describe("createStore", () => {
+  it("exposes the creator's initial state via getState", () => {
+    const store = makeCounter();
+    expect(store.getState().count).toBe(0);
+    expect(store.getState().label).toBe("init");
+  });
+
+  it("merges partial updates into state", () => {
+    const store = makeCounter();
+    store.setState({ label: "updated" });
+    expect(store.getState().label).toBe("updated");
+    expect(store.getState().count).toBe(0);
+  });
+
+  it("supports updater functions receiving current state", () => {
+    const store = makeCounter();
+    store.setState((s) => ({ count: s.count + 5 }));
+    expect(store.getState().count).toBe(5);
+  });
+
+  it("invokes actions defined by the creator", () => {
+    const store = makeCounter();
+    store.getState().increment();
+    store.getState().increment();
+    expect(store.getState().count).toBe(2);
+  });
+
+  it("notifies subscribers after each setState", () => {
+    const store = makeCounter();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.setState({ count: 1 });
+    store.setState({ count: 2 });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an unsubscribe function that stops further notifications", () => {
+    const store = makeCounter();
+    const listener = jest.fn();
+    const off = store.subscribe(listener);
+    store.setState({ count: 1 });
+    off();
+    store.setState({ count: 2 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers each notification to every subscriber", () => {
+    const store = makeCounter();
+    const a = jest.fn();
+    const b = jest.fn();
+    store.subscribe(a);
+    store.subscribe(b);
+    store.setState({ count: 7 });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores null/undefined updater results", () => {
+    const store = makeCounter();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.setState(null as any);
+    store.setState(undefined as any);
+    store.setState(() => null as any);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when all keys in the partial match current state", () => {
+    const store = makeCounter();
+    store.setState({ count: 5, label: "x" });
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.setState({ count: 5 });
+    store.setState({ count: 5, label: "x" });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("notifies when at least one key in the partial changes", () => {
+    const store = makeCounter();
+    store.setState({ count: 5, label: "x" });
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.setState({ count: 5, label: "y" });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves untouched keys when merging", () => {
+    const store = makeCounter();
+    store.setState({ count: 99 });
+    expect(store.getState().label).toBe("init");
+    expect(store.getState().increment).toBeDefined();
+  });
+
+  it("supports a single batched setState updating multiple keys at once", () => {
+    const store = makeCounter();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.setState({ count: 10, label: "batched" });
+    expect(store.getState().count).toBe(10);
+    expect(store.getState().label).toBe("batched");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("hook returns the whole state by default and re-renders on change", () => {
+    const store = makeCounter();
+    const snapshots: number[] = [];
+    const Probe = () => {
+      const s = store();
+      snapshots.push(s.count);
+      return null;
+    };
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    act(() => {
+      renderer = TestRenderer.create(createElement(Probe));
+    });
+    act(() => {
+      store.setState({ count: 1 });
+    });
+    act(() => {
+      store.setState({ count: 2 });
+    });
+    expect(snapshots).toEqual([0, 1, 2]);
+    act(() => {
+      renderer!.unmount();
+    });
+  });
+
+  it("selector returning a new object reference does not loop and stays stable per state", () => {
+    const store = makeCounter();
+    const renders: { count: number }[] = [];
+    const Probe = () => {
+      // Selector intentionally returns a fresh object every call — pre-fix this
+      // would trip React's `getSnapshot should be cached` warning and re-render
+      // forever. The cache keyed on state identity is what makes this safe.
+      const slice = store((s) => ({ count: s.count }));
+      renders.push(slice);
+      return null;
+    };
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    act(() => {
+      renderer = TestRenderer.create(createElement(Probe));
+    });
+    // No state change yet → exactly one initial render snapshot.
+    expect(renders.length).toBe(1);
+
+    act(() => {
+      store.setState({ count: 0 });
+    });
+    // No-op setState (count was already 0) → no re-render.
+    expect(renders.length).toBe(1);
+
+    act(() => {
+      store.setState({ count: 5 });
+    });
+    expect(renders.length).toBe(2);
+    expect(renders[1].count).toBe(5);
+
+    act(() => {
+      renderer!.unmount();
+    });
+  });
+
+  it("safely handles a listener that unsubscribes a sibling mid-notification", () => {
+    const store = makeCounter();
+    const callOrder: string[] = [];
+    const listenerA = jest.fn(() => {
+      callOrder.push("A");
+      offB();
+    });
+    const listenerB = jest.fn(() => callOrder.push("B"));
+    const listenerC = jest.fn(() => callOrder.push("C"));
+    store.subscribe(listenerA);
+    const offB = store.subscribe(listenerB);
+    store.subscribe(listenerC);
+
+    store.setState({ count: 1 });
+
+    // A runs first; even though A removes B mid-iteration, the snapshot
+    // means B and C still get notified this round.
+    expect(callOrder).toEqual(["A", "B", "C"]);
+
+    store.setState({ count: 2 });
+    // Next round: B is detached, only A and C fire.
+    expect(callOrder).toEqual(["A", "B", "C", "A", "C"]);
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,96 @@
+import type { MockAsleepModule, MockEventEmitter } from "./_helpers/factories.test";
+
+let mockModule: MockAsleepModule;
+let mockEmitter: MockEventEmitter;
+
+jest.mock("../AsleepModule", () => {
+  const { createMockAsleepModule } = require("./_helpers/factories.test");
+  mockModule = createMockAsleepModule();
+  return { __esModule: true, default: mockModule };
+});
+jest.mock("expo-modules-core", () => {
+  const { createMockEventEmitter } = require("./_helpers/factories.test");
+  mockEmitter = createMockEventEmitter();
+  return {
+    EventEmitter: jest.fn().mockImplementation(() => mockEmitter),
+    requireNativeModule: jest.fn(() => mockModule),
+  };
+});
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios", Version: 17 },
+  PermissionsAndroid: {
+    PERMISSIONS: { RECORD_AUDIO: "RECORD_AUDIO", POST_NOTIFICATIONS: "POST_NOTIFICATIONS" },
+    RESULTS: { GRANTED: "granted" },
+    requestMultiple: jest.fn().mockResolvedValue({ RECORD_AUDIO: "granted" }),
+  },
+}));
+
+import * as publicApi from "../index";
+
+describe("public API surface", () => {
+  it("exports only the intended runtime values", () => {
+    expect(Object.keys(publicApi).sort()).toEqual(["Asleep", "AsleepError", "useAsleep"]);
+    expect(typeof publicApi.AsleepError).toBe("function");
+  });
+
+  it("does not expose v1 surfaces", () => {
+    expect((publicApi as any).default).toBeUndefined();
+    expect((publicApi as any).AsleepSDK).toBeUndefined();
+    expect((publicApi as any).asleepStore).toBeUndefined();
+  });
+
+  it("imports without attaching native listeners", () => {
+    expect(mockEmitter.addListener).not.toHaveBeenCalled();
+  });
+});
+
+describe("Asleep escape hatch", () => {
+  it("has exactly four members", () => {
+    expect(Object.keys(publicApi.Asleep).sort()).toEqual(["addEventListener", "getState", "initialize", "subscribe"]);
+  });
+
+  it("initializes the store bridge and cleans it up", () => {
+    const cleanup = publicApi.Asleep.initialize();
+    mockEmitter.__emit("onUserJoined", { userId: "user" });
+    expect(publicApi.Asleep.getState().userId).toBe("user");
+    cleanup();
+  });
+
+  it("getState exposes public actions but no internal facts", () => {
+    const state = publicApi.Asleep.getState();
+    expect(typeof state.startTracking).toBe("function");
+    expect(typeof state.hasRequiredPermissions).toBe("function");
+    expect(state).not.toHaveProperty("showDebugLog");
+    expect(state).not.toHaveProperty("hasCheckedStatus");
+  });
+
+  it("subscribe ignores internal-only state changes", () => {
+    const listener = jest.fn();
+    const unsubscribe = publicApi.Asleep.subscribe(listener);
+    publicApi.Asleep.getState().enableLog(true);
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("subscribe receives public projection changes", () => {
+    const cleanup = publicApi.Asleep.initialize();
+    const listener = jest.fn();
+    const unsubscribe = publicApi.Asleep.subscribe(listener);
+    mockEmitter.__emit("onTrackingCreated", { sessionId: "session" });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].sessionId).toBe("session");
+    unsubscribe();
+    cleanup();
+  });
+
+  it("addEventListener forwards to the emitter and returns cleanup", () => {
+    const listener = jest.fn();
+    const unsubscribe = publicApi.Asleep.addEventListener("onTrackingCreated", listener);
+    mockEmitter.__emit("onTrackingCreated", { sessionId: "session" });
+    expect(listener).toHaveBeenCalledWith({ sessionId: "session" });
+    unsubscribe();
+    listener.mockClear();
+    mockEmitter.__emit("onTrackingCreated", { sessionId: "later" });
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,315 +1,59 @@
-import { EventEmitter } from "expo-modules-core";
 import { useEffect } from "react";
-import { Alert } from "react-native";
+import type { AsleepEventType } from "./Asleep.types";
 import {
-  AsleepConfig,
-  AsleepSetupConfig,
-  AsleepEventType,
-  AsleepReport,
-  AsleepSession,
-  AsleepAverageReport,
-  TrackingConfig,
-} from "./Asleep.types";
-import AsleepModule from "./AsleepModule";
-import { useAsleepStore, initializeAsleepListeners } from "./AsleepStore";
+  asleepActions,
+  initializeAsleepListeners,
+  toPublicState,
+  useAsleepStore,
+  type AsleepPublicApi,
+} from "./AsleepStore";
 
-const emitter = new EventEmitter(AsleepModule);
-
-class Asleep {
-  private listeners: {
-    [K in keyof AsleepEventType]?: ((data: AsleepEventType[K]) => void)[];
-  } = {};
-
-  setup = async (config: AsleepSetupConfig): Promise<void> => {
-    try {
-      await AsleepModule.setup(config.apiKey, config.baseUrl, config.callbackUrl, config.service, config.enableODA);
-    } catch (error) {
-      console.error("setup error:", error);
-      throw error;
-    }
-  };
-
-  initAsleepConfig = async (config: AsleepConfig): Promise<void> => {
-    try {
-      const result = await AsleepModule.initAsleepConfig(
-        config.apiKey,
-        config.userId,
-        config.baseUrl,
-        config.callbackUrl,
-      );
-      return result;
-    } catch (error) {
-      console.error("initAsleepConfig error:", error);
-      throw error;
-    }
-  };
-
-  startTracking = async (config?: TrackingConfig): Promise<void> => {
-    const permission = await this.requestRequiredPermissions();
-    if (!permission) {
-      Alert.alert("Microphone permission denied");
-      throw new Error("Microphone permission denied");
-    }
-
-    return AsleepModule.startTracking(config);
-  };
-
-  stopTracking = async (): Promise<string> => {
-    return AsleepModule.stopTracking();
-  };
-
-  isTracking = (): boolean => {
-    return AsleepModule.isTracking();
-  };
-
-  getReport = async (sessionId: string): Promise<AsleepReport> => {
-    const report = await AsleepModule.getReport(sessionId);
-    return this.convertKeysToCamelCase(report);
-  };
-
-  getReportList = async (fromDate: string, toDate: string): Promise<AsleepSession[]> => {
-    const reportList = await AsleepModule.getReportList(fromDate, toDate);
-    return reportList.map((session: any) => {
-      const converted = this.convertKeysToCamelCase(session);
-      // Normalize property names to match other session types
-      return {
-        id: converted.sessionId || converted.id,
-        state: converted.state,
-        startTime: converted.sessionStartTime || converted.startTime,
-        endTime: converted.sessionEndTime || converted.endTime,
-        createdTimezone: converted.createdTimezone,
-        unexpectedEndTime: converted.unexpectedEndTime,
-        lastReceivedSeqNum: converted.lastReceivedSeqNum,
-        timeInBed: converted.timeInBed,
-      };
-    });
-  };
-
-  deleteSession = async (sessionId: string): Promise<void> => {
-    return AsleepModule.deleteSession(sessionId);
-  };
-
-  getAverageReport = async (fromDate: string, toDate: string): Promise<AsleepAverageReport> => {
-    const averageReport = await AsleepModule.getAverageReport(fromDate, toDate);
-    return this.convertKeysToCamelCase(averageReport);
-  };
-
-  /**
-   * @deprecated Use requestRequiredPermissions instead. This method will be removed in a future version.
-   */
-  requestMicrophonePermission = async (): Promise<boolean> => {
-    console.warn(
-      "[AsleepSDK] requestMicrophonePermission is deprecated. Please use requestRequiredPermissions instead.",
-    );
-    return this.requestRequiredPermissions();
-  };
-
-  requestRequiredPermissions = async (): Promise<boolean> => {
-    return AsleepModule.requestRequiredPermissions();
-  };
-
-  setCustomNotification = async (_title: string, _text: string): Promise<void> => {
-    // Native method removed; notification config now flows through startTracking options.
-    console.warn(
-      "[Asleep] setCustomNotification is deprecated and a no-op; pass `{ android: { notification: { title, text, icon } } }` to startTracking() instead",
-    );
-  };
-
-  private convertKeysToCamelCase = (obj: any): any => {
-    if (Array.isArray(obj)) {
-      return obj.map(this.convertKeysToCamelCase);
-    } else if (obj !== null && obj.constructor === Object) {
-      return Object.keys(obj).reduce((acc, key) => {
-        const camelKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
-        acc[camelKey] = this.convertKeysToCamelCase(obj[key]);
-        return acc;
-      }, {} as any);
-    }
-    return obj;
-  };
-
-  addEventListener<K extends keyof AsleepEventType>(eventType: K, listener: (data: AsleepEventType[K]) => void) {
-    if (!this.listeners[eventType]) {
-      this.listeners[eventType] = [];
-    }
-    this.listeners[eventType]!.push(listener);
-
-    const subscription = emitter.addListener(eventType, listener);
-
-    return subscription;
-  }
-
-  removeAllListeners = <K extends keyof AsleepEventType>(eventType: K) => {
-    if (this.listeners[eventType]) {
-      this.listeners[eventType] = [];
-    }
-    emitter.removeAllListeners(eventType as string);
-  };
-}
-
-export const useAsleep = () => {
-  const {
-    didClose,
-    isTracking,
-    isRecoveryRequired,
-    error,
-    errorInfo,
-    userId,
-    sessionId,
-    log,
-    setup,
-    initAsleepConfig,
-    checkAndRestoreTracking,
-    checkBatteryOptimization,
-    requestBatteryOptimizationExemption,
-    startTracking,
-    stopTracking,
-    resumeTracking,
-    getReport,
-    getReportList,
-    getAverageReport,
-    deleteSession,
-    enableLog,
-    setCustomNotification,
-    requestMicrophonePermission,
-    requestRequiredPermissions,
-    requestAnalysis,
-    isODAEnabled,
-    analysisResult,
-    isAnalyzing,
-    isTrackingPaused,
-    getTrackingDurationMinutes,
-    isInitialized,
-    isSetupInProgress,
-    isSetupComplete,
-    hasCheckedStatus,
-    hasCheckedBatteryOptimization,
-    clearError,
-  } = useAsleepStore();
+export const useAsleep = (): AsleepPublicApi => {
+  const state = useAsleepStore(toPublicState);
 
   useEffect(() => {
-    const cleanup = initializeAsleepListeners();
-    return cleanup;
+    return initializeAsleepListeners();
   }, []);
 
-  return {
-    didClose,
-    isTracking,
-    isRecoveryRequired,
-    error,
-    errorInfo,
-    userId,
-    sessionId,
-    log,
-    enableLog,
-    setCustomNotification,
-    setup,
-    initAsleepConfig,
-    checkAndRestoreTracking,
-    checkBatteryOptimization,
-    requestBatteryOptimizationExemption,
-    startTracking,
-    stopTracking,
-    resumeTracking,
-    getReport,
-    getReportList,
-    getAverageReport,
-    deleteSession,
-    requestMicrophonePermission,
-    requestRequiredPermissions,
-    requestAnalysis,
-    isODAEnabled,
-    analysisResult,
-    isAnalyzing,
-    isTrackingPaused,
-    getTrackingDurationMinutes,
-    isInitialized,
-    isSetupInProgress,
-    isSetupComplete,
-    hasCheckedStatus,
-    hasCheckedBatteryOptimization,
-    clearError,
-  };
+  return state;
 };
 
-export const asleepStore = useAsleepStore;
-
-export const AsleepSDK = {
-  setup: (config: AsleepSetupConfig) => useAsleepStore.getState().setup(config),
-
-  initAsleepConfig: (config: AsleepConfig) => useAsleepStore.getState().initAsleepConfig(config),
-
-  checkAndRestoreTracking: () => useAsleepStore.getState().checkAndRestoreTracking(),
-
-  checkBatteryOptimization: () => useAsleepStore.getState().checkBatteryOptimization(),
-
-  requestBatteryOptimizationExemption: () => useAsleepStore.getState().requestBatteryOptimizationExemption(),
-
-  startTracking: (config?: TrackingConfig) => useAsleepStore.getState().startTracking(config),
-
-  stopTracking: () => useAsleepStore.getState().stopTracking(),
-
-  resumeTracking: () => useAsleepStore.getState().resumeTracking(),
-
-  getReport: (sessionId: string) => useAsleepStore.getState().getReport(sessionId),
-
-  getReportList: (fromDate: string, toDate: string) => useAsleepStore.getState().getReportList(fromDate, toDate),
-
-  getAverageReport: (fromDate: string, toDate: string) => useAsleepStore.getState().getAverageReport(fromDate, toDate),
-
-  deleteSession: (sessionId: string) => useAsleepStore.getState().deleteSession(sessionId),
-
-  requestMicrophonePermission: () => useAsleepStore.getState().requestMicrophonePermission(),
-
-  requestRequiredPermissions: () => useAsleepStore.getState().requestRequiredPermissions(),
-
-  requestAnalysis: () => useAsleepStore.getState().requestAnalysis(),
-
-  isTracking: () => useAsleepStore.getState().isTracking,
-
-  isRecoveryRequired: () => useAsleepStore.getState().isRecoveryRequired,
-
-  isAnalyzing: () => useAsleepStore.getState().isAnalyzing,
-
-  isSetupInProgress: () => useAsleepStore.getState().isSetupInProgress,
-
-  isSetupComplete: () => useAsleepStore.getState().isSetupComplete,
-
-  hasCheckedStatus: () => useAsleepStore.getState().hasCheckedStatus,
-
-  hasCheckedBatteryOptimization: () => useAsleepStore.getState().hasCheckedBatteryOptimization,
-
-  getUserId: () => useAsleepStore.getState().userId,
-
-  getSessionId: () => useAsleepStore.getState().sessionId,
-
-  enableLog: (print: boolean) => useAsleepStore.getState().enableLog(print),
-
-  setCustomNotification: (title: string, text: string) => useAsleepStore.getState().setCustomNotification(title, text),
-
-  clearError: () => useAsleepStore.getState().clearError(),
-
-  initialize: () => {
-    return initializeAsleepListeners();
+export const Asleep = {
+  initialize: initializeAsleepListeners,
+  getState: (): AsleepPublicApi => toPublicState(useAsleepStore.getState()),
+  subscribe: (listener: (state: AsleepPublicApi) => void): (() => void) => {
+    let previous = toPublicState(useAsleepStore.getState());
+    return useAsleepStore.subscribe(() => {
+      const next = toPublicState(useAsleepStore.getState());
+      if (next === previous) return;
+      previous = next;
+      listener(next);
+    });
   },
+  addEventListener: <K extends keyof AsleepEventType>(
+    eventType: K,
+    listener: (data: AsleepEventType[K]) => void,
+  ): (() => void) => asleepActions.addEventListener(eventType, listener),
 };
 
-const asleep = new Asleep();
-export default asleep;
+export { AsleepError } from "./Asleep.types";
 
 export type {
+  AsleepAnalysisAck,
+  AsleepAnalysisResult,
+  AsleepAverageReport,
   AsleepConfig,
-  AsleepSetupConfig,
   AsleepErrorCategory,
-  AsleepErrorInfo,
   AsleepEventType,
+  AsleepNeverSleptSession,
   AsleepReport,
   AsleepSession,
-  AsleepAverageReport,
+  AsleepSetupConfig,
   AsleepSleptSession,
-  AsleepNeverSleptSession,
   AsleepStat,
-  AsleepAnalysisResult,
-  AsleepAnalysisAck,
+  AudioSessionOption,
+  SetupStatus,
   TrackingConfig,
+  TrackingStatus,
 } from "./Asleep.types";
+export type { AsleepActions, AsleepPublicApi, AsleepPublicState } from "./AsleepStore";

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,0 +1,84 @@
+/**
+ * Minimal state container that mirrors the slice of zustand's API this library
+ * actually uses: getState, setState (partial or updater fn), subscribe, and a
+ * hook that exposes state via React's useSyncExternalStore.
+ *
+ * Kept as an internal implementation detail so we can drop the external
+ * zustand peer dependency.
+ */
+import { useRef, useSyncExternalStore } from "react";
+
+export type StateUpdater<T> = Partial<T> | ((state: T) => Partial<T>);
+
+export type StoreApi<T> = {
+  getState: () => T;
+  setState: (updater: StateUpdater<T>) => void;
+  subscribe: (listener: () => void) => () => void;
+};
+
+export type Selector<T, S> = (state: T) => S;
+
+export type UseBoundStore<T> = {
+  (): T;
+  <S>(selector: Selector<T, S>): S;
+} & StoreApi<T>;
+
+export type StateCreator<T> = (set: StoreApi<T>["setState"], get: StoreApi<T>["getState"]) => T;
+
+export const createStore = <T extends object>(creator: StateCreator<T>): UseBoundStore<T> => {
+  const listeners = new Set<() => void>();
+  let state: T;
+
+  const setState: StoreApi<T>["setState"] = (updater) => {
+    const partial = typeof updater === "function" ? updater(state) : updater;
+    if (partial === null || partial === undefined) return;
+    let changed = false;
+    for (const key in partial) {
+      if (!Object.is((partial as T)[key], state[key])) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return;
+    state = Object.assign({}, state, partial) as T;
+    // Snapshot listeners before iterating: a listener may subscribe or
+    // unsubscribe during notification, which would otherwise skip/repeat
+    // entries per Set.prototype.forEach semantics.
+    [...listeners].forEach((listener) => listener());
+  };
+
+  const getState: StoreApi<T>["getState"] = () => state;
+
+  const subscribe: StoreApi<T>["subscribe"] = (listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  state = creator(setState, getState);
+
+  const useBoundStore = (<S>(selector?: Selector<T, S>) => {
+    // Cache the selector result keyed on the underlying state reference. When
+    // a selector returns a fresh object on every call (e.g. `s => ({ x: s.x })`),
+    // useSyncExternalStore would otherwise see a new snapshot every read and
+    // loop forever — the React 18 "getSnapshot should be cached" warning.
+    // Tracking state-identity means we recompute only when the store mutates;
+    // intermediate reads within a render return the same reference.
+    const cache = useRef<{ state: T; value: S } | null>(null);
+    const getSnapshot = () => {
+      if (!selector) return state as unknown as S;
+      if (!cache.current || cache.current.state !== state) {
+        cache.current = { state, value: selector(state) };
+      }
+      return cache.current.value;
+    };
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  }) as UseBoundStore<T>;
+
+  useBoundStore.getState = getState;
+  useBoundStore.setState = setState;
+  useBoundStore.subscribe = subscribe;
+
+  return useBoundStore;
+};


### PR DESCRIPTION
## Summary

Fresh implementation of the v2.0 API collapse, superseding #67. That branch predated v1.1.0, so instead of rebasing it through the error-classification rewrite (#70/#73/#75), the same philosophy is re-implemented from scratch on top of current `main` with those features as first-class citizens.

Core idea: **correct state by construction.**

- **Facts, not flags** — the store keeps `setupStatus` / `trackingStatus` enums; public booleans (`isTracking`, `isTrackingPaused`, `isRecoveryRequired`, `isSetupInProgress`, `isSetupComplete`) are derived through a single memoized projection shared by `useAsleep()` and `Asleep.getState()`. Illegal combinations (e.g. a terminal failure leaving `isTracking: true` forever) are unrepresentable. New additive `status` field exposes the enum directly.
- **One writer per fact, one notification per event** — every native event runs through a pure per-event transition producing exactly one `setState`. The #73/#75 five-bucket failure classification (recordingDead → recoveryRequired → terminal → transient → unknown; string buckets before the numeric `sdkCode` fallback) and all four documented native compensations are preserved.
- **One structured error object** — `AsleepError` (`code`, `category`, `sdkCode`, `caseName`, `cause`) absorbs `errorInfo`, eliminating the error↔errorInfo lockstep discipline. Success paths clear the error through a snapshot guard so a classified failure arriving mid-`await` is never clobbered. Queries throw instead of returning `null`/`[]`.
- **Side-effect-free import** — the module-level legacy `Asleep` class instance is gone; native listeners attach once via the ref-counted initializer regardless of consumer count (locked by an "imports without attaching native listeners" test).
- **Permission split** — `hasRequiredPermissions()` (check) vs `requestRequiredPermissions()` (request); `startTracking` no longer auto-requests and throws `PERMISSION_DENIED`. Two additive native methods (iOS `recordPermission` check, Android extraction of the existing startTracking check); no other native changes.
- **zustand removed** — internal 84-line vanilla store on `useSyncExternalStore`.

## Breaking changes

- `error` is `AsleepError | null` (was `string | null`) — render `error.message`
- `errorInfo` removed — read `error.category` / `error.sdkCode` / `error.caseName`
- `getReport` / `getReportList` / `getAverageReport` / `requestAnalysis` / `deleteSession` throw on failure. A session with no report throws `REPORT_NOT_FOUND`; an empty list still resolves to `[]`
- Public setters removed (`setError`, `setIsTracking`, …); `clearError` kept
- `getTrackingDurationMinutes` and public `trackingStartTime` removed
- `requestMicrophonePermission` removed (was deprecated)
- `startTracking` no longer auto-requests permissions. On Android 13+ `requestRequiredPermissions()` still requests `POST_NOTIFICATIONS`, but its return value now reflects only microphone-side grants (matching `hasRequiredPermissions()`) — a denied notification permission no longer reports failure
- Default export, `Asleep` class, `AsleepSDK` namespace, `asleepStore` removed — use `useAsleep()` or the `Asleep` escape hatch
- `zustand` peer dependency removed

Event payloads keep both `errorCode` (legacy NSError ordinal) and `sdkCode` for wire back-compat with consumers matching legacy ordinals.

Full migration table in README ("Migrating from 1.x").

## Review resolutions

- **Notification permission in the Android check** (Codex P2) — resolved in the opposite direction: `POST_NOTIFICATIONS` is not required for tracking to run, so aligning `requestRequiredPermissions()`'s return with `hasRequiredPermissions()` rather than hard-blocking notification-denied users.
- **Null report payloads** (Codex P2) — fixed: `getReport`/`getAverageReport` throw `REPORT_NOT_FOUND` on a null native payload; `getReportList` maps null to `[]`.
- **`initAsleepConfig` tracking-state guard** (Codex P2) — fixed: removed the guard v2 mistakenly added; it broke the documented restore flow (`checkAndRestoreTracking` → `initAsleepConfig`). `setup()` keeps its guard, which v1 had.
- **iOS `initAsleepConfig` resolves before user join** (Codex P2) — v1 parity, deferred to #78 (needs a product decision on offline cold-start semantics + a native change).
- **Clear `analysisResult` on terminal failure** (Codex P2) — intentionally unchanged: neither v1's terminal branch nor the normal `onTrackingClosed` path clears it; the compensation exists to make a silent close mirror a real close field-for-field.

## Test plan

- [x] 109 tests / 7 suites green (`pnpm test`) — main's suite adapted (classification, compensations, permission branches) + ported v2 suites (`createStore`, `AsleepError`, surface contract, smoke) + new coverage (import side-effect-free, one-notification-per-event, snapshot-guard races, projection derivation, null-payload guards, restore-path config)
- [x] `pnpm lint`, `pnpm build` clean
- [x] iOS Swift compile CI job green (verifies the additive native `hasRequiredPermissions`)
- [x] `console.error` spy guard retained
- [ ] sleepstar validation against the breaking surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
