### PR TITLE
ci: give AI release notes a Breaking Changes section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,9 +229,17 @@ jobs:
             Output markdown only — no preamble, no trailing commentary.
             Structure: English block first, then Korean block, separated by a horizontal rule.
             English block — header '## English' followed by sections
-            '### New Features', '### Improvements', '### Bug Fixes', '### Internal Changes'.
+            '### Breaking Changes', '### New Features', '### Improvements',
+            '### Bug Fixes', '### Internal Changes'.
             Korean block — header '## 한국어' followed by sections
-            '### 신규 기능', '### 개선', '### 버그 수정', '### 내부 변경'.
+            '### 호환성이 깨지는 변경', '### 신규 기능', '### 개선', '### 버그 수정', '### 내부 변경'.
+            Breaking Changes comes first. It covers every removed, renamed, or
+            behaviourally-changed public API; the signals are a `!` after the commit
+            type (e.g. `feat!:`) and a `BREAKING CHANGE:` footer, but also judge the
+            change itself. Never file a removed public API or a changed public
+            contract under Internal Changes — that section is only for changes a
+            consumer cannot observe. Each breaking bullet says what changed and what
+            to use instead.
             Omit empty sections; do not invent content.
             Input is a numbered list of commits; each entry contains the PR subject
             on the first line and the PR description (rationale, compatibility notes,


### PR DESCRIPTION
## Summary

The release-notes generator's section list had **no Breaking Changes heading**. For v1.2.0 that meant the actual breaking changes — removed public APIs (default export, `AsleepSDK`, `asleepStore`, public setters, `getTrackingDurationMinutes`, `requestMicrophonePermission`) and `startTracking()` no longer auto-requesting permissions — were filed under **"Internal Changes"**, the least alarming heading available. A consumer skimming that section reasonably concludes the release doesn't affect them, which is exactly backwards for a release that breaks them.

The word "breaking" appeared nowhere in the generated body; the only warnings on the v1.2.0 release were added by hand afterwards.

## Change

Adds `### Breaking Changes` / `### 호환성이 깨지는 변경` as the **first** section of each language block, and instructs the model to:

- key off the conventional-commit `!` marker (`feat!:`) and the `BREAKING CHANGE:` footer, while still judging the change itself
- never file a removed public API or changed public contract under Internal Changes — that section is for changes consumers cannot observe
- state what changed *and* what to use instead in each breaking bullet

## Follow-up already applied

[v1.2.0's published notes](https://github.com/asleep-ai/asleep-sdk-react-native/releases/tag/v1.2.0) were restructured by hand to match this shape, so the shipped release no longer buries its breaking changes.

## Test plan

- [x] `actionlint` clean
- [ ] CI green
- [ ] Verified for real on the next release that generates notes (this run's `none` mode skips note generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)