### PR TITLE
docs: add bilingual onboarding and integration guides

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,303 @@
+# react-native-asleep
+
+[English](./README.md) | 한국어
+
+Asleep의 AI 기술로 기기 마이크의 오디오를 분석하는 React Native 수면 측정 SDK입니다. 웨어러블 없이 수면 단계를 감지하고 상세 리포트를 제공합니다.
+
+> 이 SDK는 활발히 개발 중입니다. v2는 의도적으로 작은 공개 API를 제공하므로 정확한 버전으로 고정하고 업그레이드 전에 [CHANGELOG](./CHANGELOG.md)를 확인하세요.
+
+## 포함된 기능
+
+- iOS와 Android 수면 측정
+- React 컴포넌트를 위한 `useAsleep()` 훅
+- React 외부 환경을 위한 `Asleep` API
+- 측정 상태, 분석 결과, 구조화된 `AsleepError`
+- 세션 리포트, 기간별 목록, 평균 리포트
+- Android foreground service 복원과 iOS 오디오 중단 복구
+
+## 요구 사항
+
+| 구성 요소 | 기준 |
+|---|---|
+| React Native | 0.74 이상 |
+| React | 18.2 이상 |
+| iOS deployment target | 14.0 이상 |
+| Android `minSdkVersion` | 24 이상 |
+
+현재 예제 앱은 React Native 0.79.2, Expo 53, React 19.0.0, Android compile/target SDK 34를 기준으로 검증합니다.
+
+번들된 네이티브 SDK 버전은 다음과 같습니다.
+
+| 플랫폼 | 네이티브 SDK |
+|---|---|
+| iOS | 3.2.0 |
+| Android | 3.2.1 |
+
+## 설치
+
+Expo 프로젝트:
+
+```bash
+expo install react-native-asleep
+```
+
+Bare React Native 프로젝트는 먼저 Expo Modules를 설치한 뒤 패키지를 추가합니다.
+
+```bash
+npx install-expo-modules@latest
+npm install react-native-asleep
+```
+
+Bare 프로젝트의 iOS 디렉터리에서는 CocoaPods 의존성을 설치합니다.
+
+```bash
+bundle install
+bundle exec pod install
+```
+
+이 패키지는 네이티브 모듈을 포함하므로 설치하거나 버전을 변경한 뒤에는 새 네이티브 빌드가 필요합니다. Expo Go 또는 OTA 업데이트만으로는 네이티브 연동을 검증할 수 없습니다.
+
+monorepo에서 `react-native-asleep`이 상위 `node_modules`로 hoist된다면 앱의 `package.json`에 Expo autolinking 경로를 지정합니다.
+
+```json
+{
+  "expo": {
+    "autolinking": {
+      "nativeModulesDir": ".."
+    }
+  }
+}
+```
+
+## 네이티브 설정
+
+[Asleep Dashboard](https://dashboard.asleep.ai)에서 API key를 생성합니다.
+
+### iOS
+
+Expo 프로젝트는 `app.json`에 마이크 사용 설명과 백그라운드 오디오 모드를 추가합니다.
+
+```json
+{
+  "expo": {
+    "ios": {
+      "infoPlist": {
+        "NSMicrophoneUsageDescription": "수면 중 소리를 분석하기 위해 마이크를 사용합니다.",
+        "UIBackgroundModes": ["audio"]
+      }
+    }
+  }
+}
+```
+
+Bare 프로젝트는 같은 값을 앱의 `Info.plist`에 선언합니다.
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>수면 중 소리를 분석하기 위해 마이크를 사용합니다.</string>
+<key>UIBackgroundModes</key>
+<array>
+  <string>audio</string>
+</array>
+```
+
+iOS podspec은 정적 framework를 사용합니다. 프로젝트가 이미 `use_frameworks!`를 사용한다면 정적 링크로 지정하세요.
+
+```ruby
+use_frameworks! :linkage => :static
+```
+
+### Android
+
+필요한 권한과 foreground service는 라이브러리 manifest에서 선언하며 앱 manifest에 다시 복사할 필요가 없습니다. 측정 시작 전에는 다음 항목을 앱에서 확인해야 합니다.
+
+- `requestRequiredPermissions()`로 마이크 런타임 권한 요청
+- `checkBatteryOptimization()`으로 배터리 최적화 제외 여부 확인
+- 제외되지 않았다면 사용자 동작에서 `requestBatteryOptimizationExemption()` 호출
+
+Android 13 이상에서는 `requestRequiredPermissions()`가 foreground service 알림 표시를 위해 알림 권한도 요청합니다. 반환값은 측정에 필수인 마이크 권한 허용 여부를 나타냅니다.
+
+## Quick Start
+
+새 세션과 복원된 세션 모두 아래 순서를 사용합니다.
+
+```text
+checkAndRestoreTracking()
+→ initAsleepConfig()
+→ checkBatteryOptimization()
+→ 사용자 동작에서 권한 요청
+→ startTracking()
+```
+
+복원된 세션이 있어도 `initAsleepConfig()`를 항상 호출합니다. 복원은 네이티브 측정 상태를 다시 연결하고, 초기화는 현재 앱 실행에 API key와 사용자 구성을 적용하는 별도의 단계입니다.
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { Button, Platform, Text, View } from "react-native";
+import { AsleepError, useAsleep } from "react-native-asleep";
+
+export function SleepTracker() {
+  const hasBootstrapped = useRef(false);
+  const {
+    status,
+    isTracking,
+    error,
+    checkAndRestoreTracking,
+    initAsleepConfig,
+    checkBatteryOptimization,
+    requestBatteryOptimizationExemption,
+    hasRequiredPermissions,
+    requestRequiredPermissions,
+    startTracking,
+    stopTracking,
+  } = useAsleep();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (hasBootstrapped.current) return;
+    hasBootstrapped.current = true;
+
+    void (async () => {
+      try {
+        await checkAndRestoreTracking();
+        await initAsleepConfig({ apiKey: "YOUR_API_KEY" });
+        await checkBatteryOptimization();
+        setIsReady(true);
+      } catch {
+        // `error`에도 같은 AsleepError가 반영됩니다.
+      }
+    })();
+  }, [checkAndRestoreTracking, initAsleepConfig, checkBatteryOptimization]);
+
+  const handleStart = async () => {
+    try {
+      const battery = await checkBatteryOptimization();
+      if (Platform.OS === "android" && !battery.exempted) {
+        await requestBatteryOptimizationExemption();
+        // 설정에서 돌아온 뒤 checkBatteryOptimization()으로 다시 확인하세요.
+        return;
+      }
+
+      if (!(await hasRequiredPermissions())) {
+        const granted = await requestRequiredPermissions();
+        if (!granted) return;
+      }
+
+      await startTracking({
+        android: {
+          notification: {
+            title: "수면 측정 중",
+            text: "수면 분석을 위해 오디오를 처리하고 있습니다.",
+          },
+        },
+      });
+    } catch (cause) {
+      if (!(cause instanceof AsleepError)) throw cause;
+    }
+  };
+
+  const handleStop = async () => {
+    try {
+      await stopTracking();
+    } catch (cause: unknown) {
+      if (!(cause instanceof AsleepError)) throw cause;
+    }
+  };
+
+  return (
+    <View>
+      <Text>상태: {status}</Text>
+      {error ? <Text>{error.message}</Text> : null}
+      <Button
+        title={isTracking ? "측정 종료" : "측정 시작"}
+        disabled={!isReady}
+        onPress={isTracking ? handleStop : handleStart}
+      />
+    </View>
+  );
+}
+```
+
+새 ODA(On-Device Analysis) 세션을 구성할 때는 `initAsleepConfig()` 대신 `setup()`을 사용합니다. `setup()`은 활성 tracking 중에는 호출할 수 없으므로 ODA 복원 정책은 별도로 설계하세요.
+
+## 핵심 API
+
+```ts
+import {
+  Asleep,
+  AsleepError,
+  useAsleep,
+  type AsleepReport,
+  type AsleepSession,
+  type TrackingStatus,
+} from "react-native-asleep";
+```
+
+### `useAsleep()`
+
+React 컴포넌트에서 상태와 action을 사용하고 네이티브 listener 수명 주기를 관리하는 기본 API입니다.
+
+대표 상태:
+
+- `status`: `"idle"`, `"tracking"`, `"paused"`, `"recoveryRequired"`
+- `isTracking`: `status`가 `"idle"`이 아닐 때 `true` (`recordingDead`는 native session이 열려 있어도 예외적으로 `false`)
+- `isRecoveryRequired`: iOS foreground 복구가 필요한 상태
+- `sessionId`, `userId`, `analysisResult`, `error`
+
+대표 action:
+
+- 초기화: `checkAndRestoreTracking`, `initAsleepConfig`, `setup`
+- 측정: `startTracking`, `stopTracking`, `resumeTracking`
+- 권한과 배터리: `hasRequiredPermissions`, `requestRequiredPermissions`, `checkBatteryOptimization`, `requestBatteryOptimizationExemption`
+- 데이터: `requestAnalysis`, `getReport`, `getReportList`, `getAverageReport`, `deleteSession`
+
+### `Asleep`
+
+백그라운드 callback처럼 React 훅을 사용할 수 없는 곳에서는 `Asleep.initialize()`, `Asleep.getState()`, `Asleep.subscribe()`, `Asleep.addEventListener()`를 사용합니다. `initialize()`가 반환한 cleanup 함수는 해당 소유자의 수명 주기가 끝날 때 반드시 호출하세요.
+
+### 오류
+
+모든 action과 조회 API는 실패 시 `AsleepError`를 throw합니다. `message` 문자열을 분석하지 말고 `code`로 분기하세요. 측정 중 오류에는 복구 의미를 나타내는 `category`가 포함될 수 있습니다.
+
+| `error.category` | 기본 처리 |
+|---|---|
+| `terminal` | 기존 native session은 종료됨. 새 측정을 시작 |
+| `recordingDead` | 녹음기는 종료됐지만 session은 열려 있음. `stopTracking()` 후 새 측정 |
+| `recoveryRequired` | session은 살아 있음. iOS foreground에서 `resumeTracking()` |
+| `transient` | session을 유지하며 이후 상태와 업로드를 관찰 |
+| `unknown` | 정상으로 가정하지 말고 기록·관찰 |
+
+## 프로덕션 연동
+
+앱 재시작 복원, listener 수명 주기, 앱과 SDK의 상태 경계, iOS 중단 복구, 플랫폼별 분석 결과, 리포트 재시도 정책은 [한국어 Integration Guide](./docs/INTEGRATION.ko.md)를 참고하세요.
+
+## 1.x에서 마이그레이션
+
+v2에서는 중복되거나 외부에서 변경할 수 있었던 v1 API를 제거했습니다.
+
+| 1.x | v2 |
+|---|---|
+| `error: string \| null`, `errorInfo` | 하나의 `AsleepError`; `message`, `code`, `category`, `sdkCode` 사용 |
+| 리포트 실패 시 `null` 또는 `[]` 반환 | `AsleepError` throw; 빈 리포트 목록은 여전히 정상 결과 |
+| 공개 상태 setter와 raw store | 네이티브 이벤트와 SDK action만 상태 변경 |
+| `getTrackingDurationMinutes()` | 앱에서 wall-clock 시작 시각 저장 |
+| `requestMicrophonePermission()` | `requestRequiredPermissions()` |
+| `startTracking()` 내부 권한 요청 | 시작 전에 권한을 명시적으로 확인하고 요청 |
+| default export, `AsleepSDK`, `Asleep` class | `useAsleep()`과 named `Asleep` escape hatch |
+| 필수 `zustand` 의존성 | 외부 상태 라이브러리 의존성 없음 |
+
+Android 13 이상에서는 알림 권한도 계속 요청하지만, `requestRequiredPermissions()` 반환값은 측정 가능 여부를 결정하는 마이크 권한을 반영합니다. 새 버전을 정확히 고정하고 import와 오류 분기를 모두 변경한 뒤 권한 없는 cold start를 검증하세요.
+
+## 예제
+
+전체 사용 예시는 [GitHub의 example 앱](https://github.com/asleep-ai/asleep-sdk-react-native/tree/main/example)에서 확인할 수 있습니다.
+
+## 라이선스
+
+라이선스 조건은 [LICENSE.md](./LICENSE.md)를 참고하세요.
+
+## 지원
+
+- [GitHub Issues](https://github.com/asleep-ai/asleep-sdk-react-native/issues)
+- [Asleep 개발자 문서](https://docs.asleep.ai)
+- [Asleep Dashboard](https://dashboard.asleep.ai)

--- a/README.ko.md
+++ b/README.ko.md
@@ -144,6 +144,7 @@ export function SleepTracker() {
     error,
     checkAndRestoreTracking,
     initAsleepConfig,
+    addEventListener,
     checkBatteryOptimization,
     requestBatteryOptimizationExemption,
     hasRequiredPermissions,
@@ -160,14 +161,58 @@ export function SleepTracker() {
     void (async () => {
       try {
         await checkAndRestoreTracking();
-        await initAsleepConfig({ apiKey: "YOUR_API_KEY" });
+
+        const config = { apiKey: "YOUR_API_KEY" };
+        if (Platform.OS === "ios") {
+          let removeJoined = () => {};
+          let removeFailed = () => {};
+          const configurationFinished = new Promise<void>(
+            (resolve, reject) => {
+              removeJoined = addEventListener("onUserJoined", () => resolve());
+              removeFailed = addEventListener(
+                "onUserJoinFailed",
+                (failure) => {
+                  reject(
+                    new AsleepError(
+                      "USER_JOIN_FAILED",
+                      failure.detail ?? failure.error ?? "사용자 설정 실패",
+                      {
+                        sdkCode: failure.sdkCode,
+                        caseName: failure.caseName,
+                        cause: failure,
+                      },
+                    ),
+                  );
+                },
+              );
+            },
+          );
+
+          try {
+            await Promise.all([
+              initAsleepConfig(config),
+              configurationFinished,
+            ]);
+          } finally {
+            removeJoined();
+            removeFailed();
+          }
+        } else {
+          await initAsleepConfig(config);
+        }
+
         await checkBatteryOptimization();
         setIsReady(true);
       } catch {
         // `error`에도 같은 AsleepError가 반영됩니다.
       }
     })();
-  }, [checkAndRestoreTracking, initAsleepConfig, checkBatteryOptimization]);
+  }, [
+    checkAndRestoreTracking,
+    initAsleepConfig,
+    addEventListener,
+    checkBatteryOptimization,
+  ]);
 
   const handleStart = async () => {
     try {
@@ -204,19 +249,26 @@ export function SleepTracker() {
     }
   };
 
+  const shouldStop =
+    isTracking || error?.category === "recordingDead";
+
   return (
     <View>
       <Text>상태: {status}</Text>
       {error ? <Text>{error.message}</Text> : null}
       <Button
-        title={isTracking ? "측정 종료" : "측정 시작"}
+        title={shouldStop ? "측정 종료" : "측정 시작"}
         disabled={!isReady}
-        onPress={isTracking ? handleStop : handleStart}
+        onPress={shouldStop ? handleStop : handleStart}
       />
     </View>
   );
 }
 ```
+
+iOS의 `initAsleepConfig()`는 native user 설정을 비동기로 시작하지만 bridge 호출은 manager 준비 전에 반환될 수 있습니다. 위 예제처럼 호출 전에 user event를 등록하고 `onUserJoined` 또는 `onUserJoinFailed`까지 기다리세요. Android는 설정 완료 뒤 Promise가 끝나며, 복원된 service의 빠른 경로에서는 `onUserJoined`가 발생하지 않으므로 event를 추가로 기다리면 안 됩니다.
+
+`recordingDead`도 예외입니다. `isTracking`은 `false`지만 native session은 열려 있으므로 새 측정을 시작하기 전에 `stopTracking()`을 호출해야 합니다.
 
 새 ODA(On-Device Analysis) 세션을 구성할 때는 `initAsleepConfig()` 대신 `setup()`을 사용합니다. `setup()`은 활성 tracking 중에는 호출할 수 없으므로 ODA 복원 정책은 별도로 설계하세요.
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,79 @@
 # react-native-asleep
 
-Advanced sleep tracking SDK for React Native applications, powered by Asleep's AI technology.
+[English](./README.md) | [한국어](./README.ko.md)
 
-## Status
+Sleep tracking for React Native and Expo apps, powered by Asleep's AI technology. The SDK uses the device microphone, requires no wearable, and exposes one React hook plus typed data models for iOS and Android.
 
-This SDK is under active development. v2 has a deliberately small public surface; pin to exact versions and review the [CHANGELOG](./CHANGELOG.md) before upgrading.
+> This SDK is under active development. v2 has a deliberately small public surface. Pin exact versions and review the [changelog](./CHANGELOG.md) before upgrading.
 
-## Overview
+## What is included
 
-Non-invasive sleep tracking via the device microphone — no wearables required. Detects sleep stages and produces detailed reports. Works on iOS and Android, exposes a single React hook plus typed data models.
+- Microphone-based sleep tracking and Android service restoration
+- Sleep reports, session lists, average reports, and in-progress analysis
+- A shared state model across iOS and Android
+- Structured `AsleepError` values with recovery categories
+- `useAsleep()` for React and a small `Asleep` API for non-React code
+
+## Requirements
+
+| Component | Minimum |
+|---|---|
+| React Native | 0.74 |
+| React | 18.2 |
+| iOS deployment target | 14.0 |
+| Android `minSdkVersion` | 24 |
+
+The example app is currently verified with React Native 0.79.2, Expo 53, React 19.0.0, and Android compile/target SDK 34.
+
+Bundled native SDK versions:
+
+| Platform | Native SDK version |
+|---|---|
+| iOS | 3.2.0 |
+| Android | 3.2.1 |
 
 ## Installation
 
-### For Expo Managed Projects
+### Expo projects
 
 ```bash
 expo install react-native-asleep
 ```
 
-### For Bare React Native Projects
+This package contains native modules, so create a new development or store build after installing or upgrading it. It does not run in Expo Go and cannot be upgraded through an OTA update alone.
 
-This library uses the Expo Modules API. Bare RN projects need Expo modules installed once; after that, autolinking handles the rest — no `react-native.config.js` or manual native linking.
+### Bare React Native projects
 
-1. **Install Expo modules** (skip if already installed):
+This library uses the Expo Modules API. Install Expo modules once if the app does not already use them:
 
-   ```bash
-   npx install-expo-modules@latest
-   ```
+```bash
+npx install-expo-modules@latest
+npm install react-native-asleep
+```
 
-   It prompts `Install the Expo CLI integration? (Y/n)` — either answer wires the bare modules. See the [Expo bare guide](https://docs.expo.dev/bare/installing-expo-modules/) for details.
+Then install iOS pods:
 
-2. **Install the package** (`npm install` / `pnpm add` / `yarn add`):
+```bash
+cd ios
+bundle install
+bundle exec pod install
+```
 
-   ```bash
-   npm install react-native-asleep
-   ```
+Android needs no additional linking step.
 
-3. **iOS**: in `ios/`, run `bundle install` (once) then `bundle exec pod install`. The project's `Gemfile` avoids host Ruby/CocoaPods conflicts. **Android**: no extra step.
+#### Static frameworks
 
-#### Static framework note
-
-The iOS podspec sets `s.static_framework = true`. **Do not add `use_frameworks!` to your `Podfile`.** If your project already requires it, pin to static linkage:
+The iOS pod is a static framework. Do not add `use_frameworks!` only for this package. If the app already requires it, use static linkage:
 
 ```ruby
 use_frameworks! :linkage => :static
 ```
 
-`:linkage => :dynamic` is known to break Expo SDK 55 builds (see [expo/expo#44487](https://github.com/expo/expo/issues/44487), [#41556](https://github.com/expo/expo/issues/41556)).
+Dynamic linkage is known to break Expo SDK 55 builds; see [expo/expo#44487](https://github.com/expo/expo/issues/44487) and [expo/expo#41556](https://github.com/expo/expo/issues/41556).
 
-#### Monorepo / workspace projects
+#### Monorepos and workspaces
 
-If `react-native-asleep` is hoisted to a parent `node_modules`, configure autolinking in your app's `package.json`:
+If `react-native-asleep` is hoisted to a parent `node_modules`, configure Expo autolinking in the app's `package.json`:
 
 ```json
 {
@@ -62,49 +85,22 @@ If `react-native-asleep` is hoisted to a parent `node_modules`, configure autoli
 }
 ```
 
-#### Reference configuration
+## Native configuration
 
-The [example app](./example) is the reference setup. Adjacent versions are expected to work but aren't verified.
+Create an API key in the [Asleep Dashboard](https://dashboard.asleep.ai).
 
-| Component                   | Version  |
-| --------------------------- | -------- |
-| React Native                | 0.79.2   |
-| Expo                        | 53       |
-| React                       | 19.0.0   |
-| iOS deployment target       | 14.0     |
-| Android `minSdkVersion`     | 24       |
-| Android `compileSdkVersion` | 34       |
-| Android `targetSdkVersion`  | 34       |
+### iOS
 
-#### Bundled native SDK versions
+Your app must declare microphone usage and background audio.
 
-| Platform | Native SDK version |
-|---|---|
-| iOS | 3.2.0 |
-| Android | 3.2.1 |
-
-## Setup
-
-### 1. Get API Key
-
-1. Visit [Asleep Dashboard](https://dashboard.asleep.ai)
-2. Create an account and generate your API key
-3. Note your API key for configuration
-
-### 2. Permissions
-
-#### iOS — declared by your app
-
-Add the microphone usage description and audio background mode.
-
-**For Expo Managed Projects (app.json):**
+For Expo projects:
 
 ```json
 {
   "expo": {
     "ios": {
       "infoPlist": {
-        "NSMicrophoneUsageDescription": "This app needs microphone access for sleep tracking",
+        "NSMicrophoneUsageDescription": "This app uses the microphone for sleep tracking.",
         "UIBackgroundModes": ["audio"]
       }
     }
@@ -112,264 +108,245 @@ Add the microphone usage description and audio background mode.
 }
 ```
 
-**For Bare React Native Projects (ios/YourApp/Info.plist):**
+For bare React Native projects, add the equivalent entries to the app's `Info.plist`:
 
 ```xml
 <key>NSMicrophoneUsageDescription</key>
-<string>This app needs microphone access for sleep tracking</string>
+<string>This app uses the microphone for sleep tracking.</string>
 <key>UIBackgroundModes</key>
 <array>
   <string>audio</string>
 </array>
 ```
 
-#### Android — declared by the library
+### Android
 
-The library declares its own permissions; the manifest merger combines them into your app. No `<uses-permission>` entries are needed in your `AndroidManifest.xml`. For reference, the library declares:
+The library declares its required permissions and foreground service in its manifest. The manifest merger adds them to the app, so do not duplicate them only for this SDK.
 
-```xml
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
-<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-<uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
-```
-
-`RECORD_AUDIO` and `POST_NOTIFICATIONS` are runtime permissions — request them via `useAsleep().requestRequiredPermissions()` (or `PermissionsAndroid`) before starting tracking.
+`RECORD_AUDIO` is required at runtime. On Android 13 and later, `requestRequiredPermissions()` also requests `POST_NOTIFICATIONS` so the foreground-service notification can remain visible, but notification denial does not make its return value `false`.
 
 ## Quick Start
 
+The required startup order is:
+
+```text
+check for an existing Android tracking service
+→ initialize the SDK configuration
+→ check battery optimization
+→ request permissions from a user action
+→ start tracking
+```
+
+Always call `initAsleepConfig()` after `checkAndRestoreTracking()`, including when an Android service session was restored. On iOS, the restoration check is a required cross-platform prerequisite but reports no persistent service.
+
 ```tsx
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button, Text, View } from "react-native";
 import { AsleepError, useAsleep } from "react-native-asleep";
 
-function SleepTracker() {
-  const {
-    status,
-    isTracking,
-    error,
-    initAsleepConfig,
-    checkAndRestoreTracking,
-    checkBatteryOptimization,
-    hasRequiredPermissions,
-    requestRequiredPermissions,
-    startTracking,
-    stopTracking,
-  } = useAsleep();
+export function SleepTracker() {
+  const asleep = useAsleep();
+  const hasBootstrapped = useRef(false);
+  const [isReady, setIsReady] = useState(false);
+  const [bootstrapMessage, setBootstrapMessage] = useState<string | null>(null);
 
-  // Required order before startTracking: configure -> restore any in-progress session -> battery check
   useEffect(() => {
-    (async () => {
-      await initAsleepConfig({ apiKey: "YOUR_API_KEY" });
-      await checkAndRestoreTracking();
-      await checkBatteryOptimization();
-    })();
-  }, []);
+    if (hasBootstrapped.current) return;
+    hasBootstrapped.current = true;
 
-  const handleStart = async () => {
+    async function bootstrap() {
+      await asleep.checkAndRestoreTracking();
+      await asleep.initAsleepConfig({ apiKey: "YOUR_API_KEY" });
+      await asleep.checkBatteryOptimization();
+      setIsReady(true);
+    }
+
+    void bootstrap().catch((cause: unknown) => {
+      setBootstrapMessage(cause instanceof Error ? cause.message : String(cause));
+    });
+  }, [
+    asleep.checkAndRestoreTracking,
+    asleep.initAsleepConfig,
+    asleep.checkBatteryOptimization,
+  ]);
+
+  async function start() {
     try {
-      if (!(await hasRequiredPermissions())) {
-        const granted = await requestRequiredPermissions();
+      if (!(await asleep.hasRequiredPermissions())) {
+        const granted = await asleep.requestRequiredPermissions();
         if (!granted) return;
       }
 
-      await startTracking({
-        android: { notification: { title: "Sleep tracking", text: "Recording..." } },
+      const battery = await asleep.checkBatteryOptimization();
+      if (!battery.exempted) {
+        await asleep.requestBatteryOptimizationExemption();
+        return; // Check again after the user returns from Android settings.
+      }
+
+      await asleep.startTracking({
+        android: {
+          notification: {
+            title: "Sleep tracking",
+            text: "Sleep analysis is running.",
+          },
+        },
       });
-    } catch (cause) {
+    } catch (cause: unknown) {
       if (!(cause instanceof AsleepError)) throw cause;
-      // `error` is also updated reactively and rendered below.
+      // The same AsleepError is also available reactively as asleep.error.
     }
-  };
+  }
+
+  async function stop() {
+    try {
+      await asleep.stopTracking();
+    } catch (cause: unknown) {
+      if (!(cause instanceof AsleepError)) throw cause;
+    }
+  }
 
   return (
     <View>
-      <Text>Status: {status}</Text>
-      {error ? <Text>{error.message}</Text> : null}
-      <Button title={isTracking ? "Stop" : "Start"} onPress={isTracking ? stopTracking : handleStart} />
+      <Text>Status: {asleep.status}</Text>
+      {bootstrapMessage ? <Text>{bootstrapMessage}</Text> : null}
+      {asleep.error ? <Text>{asleep.error.message}</Text> : null}
+      <Button
+        title={asleep.isTracking ? "Stop tracking" : "Start tracking"}
+        disabled={!isReady}
+        onPress={asleep.isTracking ? stop : start}
+      />
     </View>
   );
 }
 ```
 
-For ODA (On-Device Analysis) mode, call `setup()` instead of `initAsleepConfig()`. See [`example/App.tsx`](./example/App.tsx) for the full flow including report fetch and event-driven state.
+Call `requestRequiredPermissions()` from a user-driven interaction. `startTracking()` checks permission but never opens a permission dialog. On Android, return from the battery settings screen and call `checkBatteryOptimization()` again before retrying.
 
-## API surface
+For ODA (On-Device Analysis), `setup()` is the configuration entry point for a new ODA session. This Quick Start documents service mode; `setup()` cannot run while a restored session is tracking.
 
-The v2 API has one reactive hook, one thin imperative escape hatch, and named value/type exports:
+## Core API
 
 ```ts
 import {
   Asleep,
   AsleepError,
   useAsleep,
-  type AsleepAverageReport,
   type AsleepReport,
   type AsleepSession,
   type TrackingStatus,
 } from "react-native-asleep";
 ```
 
-`useAsleep()` attaches the native listeners while mounted and returns the public state plus bound actions.
+### `useAsleep()`
 
-### Public state
+The primary React API. It attaches the ref-counted native listeners while mounted and returns state plus actions from the shared SDK store.
 
-The store keeps native facts internally and derives the public booleans from `status`:
+Important state:
 
 | Field | Meaning |
 |---|---|
 | `status` | `"idle"`, `"tracking"`, `"paused"`, or `"recoveryRequired"` |
-| `isTracking` | `true` for every status except `"idle"`; recovery-required sessions are still live |
-| `isTrackingPaused` | `true` only while `status` is `"paused"` |
-| `isRecoveryRequired` | `true` only while `status` is `"recoveryRequired"` |
-| `isSetupInProgress` / `isSetupComplete` | Derived setup lifecycle |
-| `sessionId` / `userId` | Current native identifiers |
-| `error` | Last `AsleepError`, or `null` |
-| `analysisResult` / `isAnalyzing` | Latest analysis event and request state |
-| `didClose` / `isODAEnabled` / `log` | Session history, mode, and opt-in debug log |
+| `isTracking` | `true` for every status except `"idle"` |
+| `isTrackingPaused` | The native session is temporarily interrupted |
+| `isRecoveryRequired` | iOS needs an explicit foreground `resumeTracking()` |
+| `isSetupComplete` | SDK configuration completed |
+| `sessionId`, `userId` | Current native identifiers |
+| `analysisResult`, `isAnalyzing` | Latest analysis event and request state |
+| `error` | The latest `AsleepError`, or `null` |
 
-`trackingStartTime`, listener bookkeeping, and mutable setters are internal implementation details.
+Important actions:
 
-### Actions
+| Area | Actions |
+|---|---|
+| Configuration and restore | `setup`, `initAsleepConfig`, `checkAndRestoreTracking` |
+| Prerequisites | `checkBatteryOptimization`, `requestBatteryOptimizationExemption`, `hasRequiredPermissions`, `requestRequiredPermissions` |
+| Tracking | `startTracking`, `stopTracking`, `resumeTracking` |
+| Reports | `getReport`, `getReportList`, `getAverageReport`, `deleteSession` |
+| Analysis | `requestAnalysis` |
+| Utilities | `addEventListener`, `enableLog`, `clearError` |
 
-The hook exposes:
+### `Asleep`
 
-- Setup and restore: `setup`, `initAsleepConfig`, `checkAndRestoreTracking`
-- Tracking: `startTracking`, `stopTracking`, `resumeTracking`
-- Reports: `getReport`, `getReportList`, `getAverageReport`, `deleteSession`, `requestAnalysis`
-- Prerequisites: `checkBatteryOptimization`, `requestBatteryOptimizationExemption`, `hasRequiredPermissions`, `requestRequiredPermissions`
-- Utilities: `enableLog`, `clearError`, `addEventListener`, and the deprecated no-op `setCustomNotification`
-
-`requestAnalysis()` returns the Android analysis result or the iOS `{ status: "requested", timestamp }` acknowledgement. On both platforms, `onAnalysisResult` is the only writer of reactive `analysisResult`.
-
-### Non-React contexts
-
-Use `Asleep` for background callbacks and other code where hooks are unavailable:
+Use the imperative escape hatch where React hooks are unavailable:
 
 ```ts
 import { Asleep } from "react-native-asleep";
 
-// Required when no mounted useAsleep() hook owns the native listener lifecycle.
-const teardown = Asleep.initialize();
-
-const unsubscribe = Asleep.subscribe(({ status, error }) => {
-  console.log(status, error?.code);
+const releaseListeners = Asleep.initialize();
+const unsubscribe = Asleep.subscribe((state) => {
+  console.log(state.status, state.error?.code);
 });
 
-const offAnalysis = Asleep.addEventListener("onAnalysisResult", (result) => {
-  console.log(result);
-});
+console.log(Asleep.getState().status);
 
-await Asleep.getState().stopTracking();
-
-offAnalysis();
 unsubscribe();
-teardown();
+releaseListeners();
 ```
 
-`initialize()` is ref-counted, so it is safe to use alongside mounted hooks. Importing the package alone does not attach native listeners.
+`Asleep.initialize()` is ref-counted and must be paired with its returned cleanup function. Importing the package alone does not attach native listeners.
 
-On iOS, `isRecoveryRequired` becomes `true` when recording cannot resume while the app is in the background. After the app returns to the foreground, call `resumeTracking()`. The flag clears only after the next successful audio upload. `resumeTracking()` is iOS-only and rejects with `UNSUPPORTED_PLATFORM` on Android.
+### Errors
 
-## Tracking lifecycle and platform compensations
-
-The library handles a number of platform quirks internally so JS sees a consistent event model:
-
-- iOS 3.2.1 `closeSessionSilently()` on 403/429 tears down a session without firing `didClose` — the wrapper detects terminal error codes and resets `isTracking` / `isAnalyzing` itself.
-- Android SDK 3.2.x emits both `onFail` and `onFinish` for fatal codes — the wrapper suppresses the spurious `onTrackingClosed` so JS doesn't misread a fatal error as a clean close.
-- iOS interruption recovery may emit duplicate `didResume` events — the wrapper deduplicates while still clearing `error`.
-- iOS audio initialization failure stops recording without closing the native session — stop and restart the session; `resumeTracking()` cannot recover it.
-
-See [AGENTS.md](./AGENTS.md#native-behavior-compensations) for the full table including upstream SDK versions and rationale.
-
-## Error classification
-
-Every failed action and native failure event produces an `AsleepError`, which extends `Error`:
+Every failed action throws `AsleepError`; the same error is stored in `useAsleep().error` when applicable.
 
 ```ts
-class AsleepError extends Error {
-  readonly code: string;
-  readonly category?: "terminal" | "recordingDead" | "recoveryRequired" | "transient" | "unknown";
-  readonly sdkCode?: number;
-  readonly caseName?: string;
-  readonly cause?: unknown;
+try {
+  await asleep.startTracking();
+} catch (cause: unknown) {
+  if (cause instanceof AsleepError) {
+    console.log(cause.code, cause.category, cause.sdkCode);
+  }
 }
 ```
 
-Branch on the stable `code`, render `message`, and forward the error itself to observability tooling. Tracking failures also carry the library's objective recovery classification in `category`; the app decides what severity to record:
+Use `code` for stable machine branching and `message` for display. Runtime tracking failures can also have one of these recovery categories:
 
-| `category` | Meaning | Suggested app-side severity |
-|---|---|---|
-| `terminal` | Native session is gone; no `onTrackingClosed` will follow. Start a new session. | error |
-| `recordingDead` | Recorder torn down but the session is still open; `stopTracking()` then start again. | error |
-| `recoveryRequired` | Tracking is alive; call `resumeTracking()` in the foreground (`isRecoveryRequired` is also set). | warning |
-| `transient` | The native session survived (e.g. one upload window failed after internal retries); later uploads continue. | warning |
-| `unknown` | Unclassified code — do not assume it is benign. | error |
+| Category | Meaning |
+|---|---|
+| `terminal` | The native session is already gone |
+| `recordingDead` | Recording stopped but the native session remains open |
+| `recoveryRequired` | The live iOS session needs a foreground resume |
+| `transient` | The native session survived the failure |
+| `unknown` | The failure is not classified; do not assume it is recoverable |
 
-```ts
-const { error } = useAsleep();
+See the integration guide for the required action for each category.
 
-useEffect(() => {
-  if (!error) return;
-  if (error.category === "recoveryRequired" || error.category === "transient") {
-    analytics.track("asleep_recoverable_error", {
-      code: error.code,
-      sdkCode: error.sdkCode,
-      category: error.category,
-    });
-  } else {
-    Sentry.captureException(error);
-  }
-}, [error]);
-```
+## Production integration
 
-`sdkCode` is the numeric code documented by the native Asleep SDKs. The legacy `errorCode` event-payload field remains for wire compatibility but is deprecated: on iOS it is a Swift enum ordinal from NSError bridging, not the documented code.
+The README covers installation and the first successful tracking flow. Before shipping, read the [Integration Guide](./docs/INTEGRATION.md) for:
 
-All actions, including report queries, throw `AsleepError` on failure. Queries no longer return `null` or `[]` as failure sentinels. Successful actions clear only the error that was present when the native call began; a classified failure event arriving during the await is preserved.
-
-## Best practices
-
-- **Permission flow**: use `hasRequiredPermissions()` for a non-interactive check, then call `requestRequiredPermissions()` from a user-initiated flow. `startTracking()` never opens a permission dialog and throws `PERMISSION_DENIED` when permission is missing.
-- **Battery optimization (Android, required)**: long sessions get killed without an exemption. Call `checkBatteryOptimization()` before `startTracking()`; if not exempted, call `requestBatteryOptimizationExemption()` and follow the system prompt. iOS's no-op call keeps cross-platform code uniform.
-- **Error handling**: gate log severity on `useAsleep().error?.category` and switch on `error.code` for category-specific UI rather than parsing message text.
-- **Non-React lifecycle**: pair every `Asleep.initialize()` with its returned teardown function.
+- cold-start restoration and listener ownership
+- app-owned versus SDK-owned state
+- Android foreground-service and battery behavior
+- iOS interruption recovery
+- recovery-category handling
+- analysis and report timing
+- real-device release checks
 
 ## Migrating from 1.x
 
-v2 deliberately removes the parallel and mutable v1 surfaces:
+v2 removes the parallel and mutable v1 surfaces:
 
-1. `error: string | null` is now `AsleepError | null`. Render `error?.message` and branch on `error?.code`.
-2. `errorInfo` is removed. Read `error.category`, `error.sdkCode`, and `error.caseName`.
-3. Report and analysis queries throw `AsleepError` on failure instead of returning `null` or `[]`. A session that has no report surfaces as code `REPORT_NOT_FOUND`; an empty report list still resolves to `[]`.
-4. Public state setters are removed. Native events and SDK actions are the sole state writers; `clearError()` remains public.
-5. `getTrackingDurationMinutes()` is removed and `trackingStartTime` is internal. Apps own wall-clock duration.
-6. `requestMicrophonePermission()` is removed. Use `requestRequiredPermissions()`.
-7. `startTracking()` no longer requests permission. Check with `hasRequiredPermissions()`, explicitly request if needed, then start.
-8. The default export, `Asleep` class, `AsleepSDK`, and raw `asleepStore` export are removed. Use `useAsleep()` or the named `Asleep` escape hatch.
-9. `zustand` is no longer a dependency. Remove it from your app if nothing else uses it.
-10. Use the additive `status: TrackingStatus` field when a single lifecycle value is clearer than multiple derived booleans.
-11. Android 13+: `requestRequiredPermissions()` still requests `POST_NOTIFICATIONS` (so the foreground-service notification stays visible), but its return value now reflects only what tracking needs to run — microphone-side permissions, matching `hasRequiredPermissions()`. In 1.x a denied notification permission made it return `false` even though tracking could start.
+| 1.x | v2 |
+|---|---|
+| `error: string \| null` and `errorInfo` | One `AsleepError`; use `message`, `code`, `category`, and `sdkCode` |
+| Report failures returned `null` or `[]` | Report APIs throw `AsleepError`; an empty report list remains a valid result |
+| Public state setters and raw store | Native events and SDK actions are the only writers |
+| `getTrackingDurationMinutes()` | Store a wall-clock start time in the app |
+| `requestMicrophonePermission()` | `requestRequiredPermissions()` |
+| `startTracking()` requested permission | Check and request permission explicitly before starting |
+| Default export, `AsleepSDK`, and `Asleep` class | `useAsleep()` and the named thin `Asleep` escape hatch |
+| Required `zustand` dependency | No external state-library dependency |
 
-## Troubleshooting
-
-- **`PERMISSION_DENIED` from `startTracking`**: check and request microphone permission from a user-initiated flow, then retry.
-- **`MISSING_PREREQUISITE` from `startTracking`**: call `checkAndRestoreTracking()` and `checkBatteryOptimization()` before `startTracking()`.
-- **Tracking ends unexpectedly on Android**: battery optimization is on; call `checkBatteryOptimization()` and follow the prompt.
-- **Network errors**: verify API key and connectivity.
-
-Enable debug logs with `useAsleep().enableLog(true)`.
+Android 13 and later still request notification permission, but `requestRequiredPermissions()` now returns the microphone-side result that determines whether tracking can start. Pin the new version, update all imports and error branches, and test cold-start permissions before release.
 
 ## Example app
 
-See [`example/`](./example) for a full implementation.
+See the [example app on GitHub](https://github.com/asleep-ai/asleep-sdk-react-native/tree/main/example) for a runnable implementation.
 
 ## License
 
-MIT.
+See [LICENSE.md](./LICENSE.md).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Always call `initAsleepConfig()` after `checkAndRestoreTracking()`, including wh
 
 ```tsx
 import { useEffect, useRef, useState } from "react";
-import { Button, Text, View } from "react-native";
+import { Button, Platform, Text, View } from "react-native";
 import { AsleepError, useAsleep } from "react-native-asleep";
 
 export function SleepTracker() {
@@ -156,7 +156,41 @@ export function SleepTracker() {
 
     async function bootstrap() {
       await asleep.checkAndRestoreTracking();
-      await asleep.initAsleepConfig({ apiKey: "YOUR_API_KEY" });
+
+      const config = { apiKey: "YOUR_API_KEY" };
+      if (Platform.OS === "ios") {
+        let removeJoined = () => {};
+        let removeFailed = () => {};
+        const configurationFinished = new Promise<void>((resolve, reject) => {
+          removeJoined = asleep.addEventListener("onUserJoined", () => resolve());
+          removeFailed = asleep.addEventListener("onUserJoinFailed", (failure) => {
+            reject(
+              new AsleepError(
+                "USER_JOIN_FAILED",
+                failure.detail ?? failure.error ?? "User join failed.",
+                {
+                  sdkCode: failure.sdkCode,
+                  caseName: failure.caseName,
+                  cause: failure,
+                },
+              ),
+            );
+          });
+        });
+
+        try {
+          await Promise.all([
+            asleep.initAsleepConfig(config),
+            configurationFinished,
+          ]);
+        } finally {
+          removeJoined();
+          removeFailed();
+        }
+      } else {
+        await asleep.initAsleepConfig(config);
+      }
+
       await asleep.checkBatteryOptimization();
       setIsReady(true);
     }
@@ -167,6 +201,7 @@ export function SleepTracker() {
   }, [
     asleep.checkAndRestoreTracking,
     asleep.initAsleepConfig,
+    asleep.addEventListener,
     asleep.checkBatteryOptimization,
   ]);
 
@@ -205,15 +240,18 @@ export function SleepTracker() {
     }
   }
 
+  const shouldStop =
+    asleep.isTracking || asleep.error?.category === "recordingDead";
+
   return (
     <View>
       <Text>Status: {asleep.status}</Text>
       {bootstrapMessage ? <Text>{bootstrapMessage}</Text> : null}
       {asleep.error ? <Text>{asleep.error.message}</Text> : null}
       <Button
-        title={asleep.isTracking ? "Stop tracking" : "Start tracking"}
+        title={shouldStop ? "Stop tracking" : "Start tracking"}
         disabled={!isReady}
-        onPress={asleep.isTracking ? stop : start}
+        onPress={shouldStop ? stop : start}
       />
     </View>
   );
@@ -221,6 +259,10 @@ export function SleepTracker() {
 ```
 
 Call `requestRequiredPermissions()` from a user-driven interaction. `startTracking()` checks permission but never opens a permission dialog. On Android, return from the battery settings screen and call `checkBatteryOptimization()` again before retrying.
+
+On iOS, `initAsleepConfig()` starts asynchronous user configuration but its bridge call can return before the native managers are ready. Register the user events before calling it and wait for `onUserJoined` or `onUserJoinFailed`, as shown above. Android resolves `initAsleepConfig()` after configuration; do not wait for `onUserJoined` there because a restored-service fast path does not emit it.
+
+The `recordingDead` category is another deliberate exception: `isTracking` is `false`, but the native session remains open, so the action must still call `stopTracking()` before starting a new session.
 
 For ODA (On-Device Analysis), `setup()` is the configuration entry point for a new ODA session. This Quick Start documents service mode; `setup()` cannot run while a restored session is tracking.
 

--- a/docs/INTEGRATION.ko.md
+++ b/docs/INTEGRATION.ko.md
@@ -16,7 +16,7 @@
 앱 시작
 → useAsleep() mount 또는 Asleep.initialize()
 → checkAndRestoreTracking()
-→ initAsleepConfig()                    // 복원 여부와 관계없이 항상 호출
+→ initAsleepConfig()                    // iOS는 user event까지 대기
 → checkBatteryOptimization()
 → 사용자 동작에서 권한 요청
 → startTracking()                       // 활성 세션이 없을 때만
@@ -42,7 +42,8 @@ iOS bridge는 복원 가능한 session을 보고하지 않지만 `startTracking(
 
 ```tsx
 import { useCallback, useState } from "react";
-import { useAsleep } from "react-native-asleep";
+import { Platform } from "react-native";
+import { AsleepError, useAsleep } from "react-native-asleep";
 
 export function useAsleepBootstrap(apiKey: string, stableUserId?: string) {
   const asleep = useAsleep();
@@ -51,10 +52,48 @@ export function useAsleepBootstrap(apiKey: string, stableUserId?: string) {
 
   const initialize = useCallback(async () => {
     await asleep.checkAndRestoreTracking();
-    await asleep.initAsleepConfig({
+
+    const config = {
       apiKey,
       userId: stableUserId,
-    });
+    };
+
+    if (Platform.OS === "ios") {
+      let removeJoined = () => {};
+      let removeFailed = () => {};
+      const configurationFinished = new Promise<void>((resolve, reject) => {
+        removeJoined = asleep.addEventListener("onUserJoined", () => resolve());
+        removeFailed = asleep.addEventListener(
+          "onUserJoinFailed",
+          (failure) => {
+            reject(
+              new AsleepError(
+                "USER_JOIN_FAILED",
+                failure.detail ?? failure.error ?? "사용자 설정 실패",
+                {
+                  sdkCode: failure.sdkCode,
+                  caseName: failure.caseName,
+                  cause: failure,
+                },
+              ),
+            );
+          },
+        );
+      });
+
+      try {
+        await Promise.all([
+          asleep.initAsleepConfig(config),
+          configurationFinished,
+        ]);
+      } finally {
+        removeJoined();
+        removeFailed();
+      }
+    } else {
+      await asleep.initAsleepConfig(config);
+    }
+
     const battery = await asleep.checkBatteryOptimization();
 
     setIsBatteryExempted(battery.exempted);
@@ -64,12 +103,15 @@ export function useAsleepBootstrap(apiKey: string, stableUserId?: string) {
     stableUserId,
     asleep.checkAndRestoreTracking,
     asleep.initAsleepConfig,
+    asleep.addEventListener,
     asleep.checkBatteryOptimization,
   ]);
 
   return { ...asleep, initialize, isReady, isBatteryExempted };
 }
 ```
+
+iOS의 bridge 호출은 native user 설정을 시작한 뒤 tracking/report manager가 준비되기 전에 반환될 수 있습니다. 따라서 호출 전에 `onUserJoined`와 `onUserJoinFailed`를 등록하고 둘 중 하나가 발생할 때까지 기다립니다. `isSetupComplete`만으로 iOS 준비 완료를 판단하면 안 됩니다. 현재 bridge action은 user-join delegate가 native manager를 만들기 전에 이 값을 갱신할 수 있습니다. Android에서는 `initAsleepConfig()` 자체의 Promise만 기다립니다. 복원된 service의 빠른 경로는 Promise를 resolve하지만 `onUserJoined`를 보내지 않기 때문입니다.
 
 앱의 integration owner에서 `initialize()`를 한 번 호출하고 실패하면 tracking UI를 비활성화한 채 앱이 소유한 재시도 동작을 제공하세요.
 
@@ -182,6 +224,18 @@ async function startSleepTracking() {
     },
   });
 }
+
+async function handleTrackingPress() {
+  const shouldStop =
+    asleep.isTracking || asleep.error?.category === "recordingDead";
+
+  if (shouldStop) {
+    await asleep.stopTracking();
+    return;
+  }
+
+  await startSleepTracking();
+}
 ```
 
 `startTracking()`은 다음 조건을 직접 검증하고 `AsleepError`를 throw합니다.
@@ -195,7 +249,7 @@ async function startSleepTracking() {
 
 정상 종료는 `stopTracking()`이 성공한 뒤 앱이 관리하는 타이머와 부가 상태를 정리합니다. 먼저 앱 상태를 지우면 native 종료 실패 후 복구할 근거를 잃을 수 있습니다.
 
-`recordingDead` 오류에서는 `isTracking === false`여도 native session이 열려 있으므로 예외적으로 `stopTracking()`을 호출해야 합니다. 반면 `terminal`은 native session이 이미 종료된 상태입니다.
+버튼 문구와 동작도 같은 `shouldStop` 조건을 사용하세요. `recordingDead` 오류에서는 `isTracking === false`여도 native session이 열려 있으므로 예외적으로 `stopTracking()`을 호출해야 합니다. 반면 `terminal`은 native session이 이미 종료된 상태입니다.
 
 ## 6. 플랫폼 차이와 복구
 

--- a/docs/INTEGRATION.ko.md
+++ b/docs/INTEGRATION.ko.md
@@ -1,0 +1,339 @@
+# react-native-asleep Integration Guide
+
+[English](./INTEGRATION.md) | 한국어
+
+[README로 돌아가기](../README.ko.md)
+
+이 문서는 `react-native-asleep`을 실제 서비스 앱에 연동할 때 필요한 수명 주기, 상태 소유권, 복구, 리포트 처리, 출시 전 검증을 설명합니다. 설치와 첫 측정은 먼저 [README](../README.ko.md)를 참고하세요.
+
+아래의 복원 후 항상 초기화하는 흐름은 `initAsleepConfig()`를 사용하는 서비스 방식의 수면 측정을 기준으로 합니다. 새 ODA(On-Device Analysis) 세션은 `setup()`으로 구성하지만, `setup()`은 활성 tracking 중에는 호출할 수 없으므로 복원 정책을 별도로 설계해야 합니다.
+
+## 1. 전체 수명 주기
+
+정상 경로와 복원 경로 모두 같은 초기화 단계를 거칩니다.
+
+```text
+앱 시작
+→ useAsleep() mount 또는 Asleep.initialize()
+→ checkAndRestoreTracking()
+→ initAsleepConfig()                    // 복원 여부와 관계없이 항상 호출
+→ checkBatteryOptimization()
+→ 사용자 동작에서 권한 요청
+→ startTracking()                       // 활성 세션이 없을 때만
+→ stopTracking()
+→ 리포트 조회
+```
+
+각 단계의 역할은 다릅니다.
+
+| 단계 | 역할 |
+|---|---|
+| `checkAndRestoreTracking()` | Android의 기존 native session 존재 여부를 확인하고 service에 다시 연결 |
+| `initAsleepConfig()` | 현재 앱 실행에 API key, `userId`, endpoint 구성을 적용 |
+| `checkBatteryOptimization()` | `startTracking()`의 선행 조건을 충족하고 Android 장기 측정 가능 여부를 확인 |
+| `requestRequiredPermissions()` | 사용자 동작에서 런타임 권한 요청 |
+| `startTracking()` | 새 native session 시작 |
+
+복원된 session이 있어도 초기화를 생략하지 않습니다. `initAsleepConfig()`는 tracking 상태에서도 호출할 수 있도록 설계되어 있습니다. 반대로 기존 session이 활성 상태라면 `startTracking()`을 다시 호출하지 않습니다.
+
+iOS bridge는 복원 가능한 session을 보고하지 않지만 `startTracking()`의 공통 선행 조건을 충족하기 위해 `checkAndRestoreTracking()`을 호출합니다. 실제 service 재연결은 Android 전용입니다.
+
+앱 최상단의 한 곳에서 이 순서를 실행하고, 여러 화면이 각각 초기화를 시작하지 않도록 하세요.
+
+```tsx
+import { useCallback, useState } from "react";
+import { useAsleep } from "react-native-asleep";
+
+export function useAsleepBootstrap(apiKey: string, stableUserId?: string) {
+  const asleep = useAsleep();
+  const [isReady, setIsReady] = useState(false);
+  const [isBatteryExempted, setIsBatteryExempted] = useState(false);
+
+  const initialize = useCallback(async () => {
+    await asleep.checkAndRestoreTracking();
+    await asleep.initAsleepConfig({
+      apiKey,
+      userId: stableUserId,
+    });
+    const battery = await asleep.checkBatteryOptimization();
+
+    setIsBatteryExempted(battery.exempted);
+    setIsReady(true);
+  }, [
+    apiKey,
+    stableUserId,
+    asleep.checkAndRestoreTracking,
+    asleep.initAsleepConfig,
+    asleep.checkBatteryOptimization,
+  ]);
+
+  return { ...asleep, initialize, isReady, isBatteryExempted };
+}
+```
+
+앱의 integration owner에서 `initialize()`를 한 번 호출하고 실패하면 tracking UI를 비활성화한 채 앱이 소유한 재시도 동작을 제공하세요.
+
+API key는 소스에 커밋하지 말고 앱의 배포 환경에 맞는 secret/config 관리 방식을 사용하세요. SDK의 `userId`와 앱 계정의 대응 관계, ID 저장 및 변경 정책은 소비 앱이 소유합니다. 활성 session 중에는 다른 `userId`로 다시 초기화하지 마세요.
+
+## 2. 권한과 Android 배터리 최적화
+
+`startTracking()`은 권한 대화상자를 열지 않습니다. 먼저 비대화형 확인을 하고, 버튼 탭처럼 사용자가 원인을 이해할 수 있는 동작에서 권한을 요청하세요.
+
+```ts
+async function ensureTrackingPermission() {
+  if (await asleep.hasRequiredPermissions()) return true;
+  return asleep.requestRequiredPermissions();
+}
+```
+
+Android에서는 `checkBatteryOptimization()` 결과가 `exempted: false`이면 사용자 동작에서 `requestBatteryOptimizationExemption()`을 호출합니다. 시스템 설정 화면에서 돌아온 뒤 실제 상태를 다시 확인하세요.
+
+```ts
+async function prepareAndroidBattery() {
+  const battery = await asleep.checkBatteryOptimization();
+  if (battery.exempted) return true;
+
+  await asleep.requestBatteryOptimizationExemption();
+  return false;
+}
+```
+
+iOS의 `checkBatteryOptimization()`은 `{ exempted: true, platform: "ios" }`를 반환하므로 플랫폼 공통 순서를 유지할 수 있습니다.
+
+Android 13 이상에서는 `requestRequiredPermissions()`가 알림 권한도 요청하지만 반환값은 마이크 측정 가능 여부를 나타냅니다. 알림 거절 UX는 앱 정책으로 별도 처리할 수 있습니다.
+
+## 3. 앱 상태와 SDK 상태의 경계
+
+SDK는 native SDK에서 확인한 사실을 저장하고, 제품 정책과 영속 상태는 앱이 관리합니다.
+
+| SDK가 관리 | 앱이 관리 |
+|---|---|
+| `status`, `isTracking`, `isTrackingPaused` | 화면 상태와 사용자 안내 |
+| `isRecoveryRequired`, `error` | 재시도 횟수와 재시도 시점 |
+| `sessionId`, `userId` | SDK ID와 앱 계정의 연결 및 영속화 |
+| `analysisResult`, `isAnalyzing` | 분석 결과의 표시와 서버 동기화 |
+| `didClose`, `isSetupComplete` | 측정 시작 wall-clock, 타이머, 알람 |
+
+`trackingStartTime`은 공개 API가 아닙니다. 경과 시간은 앱이 시작 시각을 저장하고 현재 시각과의 차이로 계산하세요. interval 횟수를 누적하면 앱이 백그라운드에 있는 동안 시간이 틀어질 수 있습니다.
+
+다음 항목은 SDK에 넣지 않고 소비 앱에 둡니다.
+
+- 인증과 cloud sync
+- Alarm, Live Activity, Widget, Health 연동
+- 권한 거절 화면, alert, toast
+- analytics와 observability
+- 리포트 재시도 및 사용자 알림 정책
+- 수면 단계 문구와 제품별 지표 계산
+
+부가 기능의 실패가 `startTracking()`이나 `stopTracking()` 실행 자체를 건너뛰게 하지 않도록 경계를 분리하세요.
+
+## 4. listener 수명 주기
+
+`useAsleep()`은 mount 시 native listener를 연결하고 unmount 시 정리합니다. 앱의 안정적인 상위 컴포넌트에서 훅을 유지하면 화면 전환 중 listener가 불필요하게 반복 연결되는 것을 피할 수 있습니다.
+
+React 훅을 사용할 수 없는 백그라운드 callback이나 서비스 계층에서는 `Asleep`을 사용합니다.
+
+```ts
+import { Asleep } from "react-native-asleep";
+
+const teardown = Asleep.initialize();
+
+const unsubscribe = Asleep.subscribe((state) => {
+  console.log(state.status, state.error?.code);
+});
+
+const removeAnalysisListener = Asleep.addEventListener(
+  "onAnalysisResult",
+  (result) => {
+    console.log(result);
+  },
+);
+
+// 해당 소유자의 수명 주기가 끝날 때
+removeAnalysisListener();
+unsubscribe();
+teardown();
+```
+
+`Asleep.initialize()`는 ref-counted이므로 mount된 `useAsleep()`과 함께 사용할 수 있습니다. 다만 호출한 소유자는 반환된 teardown 함수를 반드시 실행해야 합니다. 패키지를 import하는 것만으로는 listener가 연결되지 않습니다.
+
+## 5. 측정 시작과 종료
+
+새 측정은 bootstrap이 완료되고 활성 session이 없을 때만 시작합니다.
+
+```ts
+async function startSleepTracking() {
+  if (!isReady || asleep.isTracking) return;
+
+  if (!(await prepareAndroidBattery())) {
+    return;
+  }
+
+  if (!(await ensureTrackingPermission())) {
+    return;
+  }
+
+  await asleep.startTracking({
+    android: {
+      notification: {
+        title: "수면 측정 중",
+        text: "수면 분석을 위해 오디오를 처리하고 있습니다.",
+      },
+    },
+  });
+}
+```
+
+`startTracking()`은 다음 조건을 직접 검증하고 `AsleepError`를 throw합니다.
+
+- 앱 시작 후 `checkAndRestoreTracking()`을 호출했는가
+- `checkBatteryOptimization()`을 호출했는가
+- setup이 진행 중이 아닌가
+- 이미 측정 중이 아닌가
+- 마이크 권한이 있는가
+- Android 배터리 최적화에서 제외됐는가
+
+정상 종료는 `stopTracking()`이 성공한 뒤 앱이 관리하는 타이머와 부가 상태를 정리합니다. 먼저 앱 상태를 지우면 native 종료 실패 후 복구할 근거를 잃을 수 있습니다.
+
+`recordingDead` 오류에서는 `isTracking === false`여도 native session이 열려 있으므로 예외적으로 `stopTracking()`을 호출해야 합니다. 반면 `terminal`은 native session이 이미 종료된 상태입니다.
+
+## 6. 플랫폼 차이와 복구
+
+### Android
+
+- 측정은 별도 foreground service에서 실행됩니다.
+- 앱 process가 다시 시작되면 `checkAndRestoreTracking()`이 살아 있는 측정을 확인하고 service에 재연결합니다.
+- 장기 측정 전 배터리 최적화 제외 여부를 확인해야 합니다.
+- `requestAnalysis()` Promise가 전체 분석 결과를 반환하고 `onAnalysisResult` 이벤트도 발생시킵니다.
+
+### iOS
+
+- 백그라운드 측정을 위해 `UIBackgroundModes: ["audio"]`가 필요합니다.
+- 전화나 다른 오디오 session 때문에 측정이 `paused` 또는 `recoveryRequired` 상태가 될 수 있습니다.
+- `resumeTracking()`은 iOS 전용이며 Android에서는 `UNSUPPORTED_PLATFORM`을 throw합니다.
+- `requestAnalysis()` Promise는 `{ status: "requested", timestamp }` acknowledgment를 반환하고 실제 결과는 `onAnalysisResult` 이벤트로 도착합니다.
+
+iOS에서 `isRecoveryRequired === true`이고 앱이 foreground로 돌아오면 중복 호출을 막으며 `resumeTracking()`을 호출하세요. Promise 성공만으로 복구 완료로 판단하지 않습니다. 다음 audio upload가 성공해야 `isRecoveryRequired`가 `false`로 바뀝니다.
+
+```tsx
+import { useEffect, useRef } from "react";
+import { AppState, Platform } from "react-native";
+import type { AsleepPublicApi } from "react-native-asleep";
+
+export function useIosRecovery(asleep: AsleepPublicApi) {
+  const resumeInFlight = useRef(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "ios") return;
+
+    const resumeIfNeeded = (appState: string) => {
+      if (
+        appState !== "active" ||
+        !asleep.isRecoveryRequired ||
+        resumeInFlight.current
+      ) {
+        return;
+      }
+
+      resumeInFlight.current = true;
+      void asleep
+        .resumeTracking()
+        .catch(() => {
+          // 분류된 실패는 asleep.error에서도 확인할 수 있습니다.
+        })
+        .finally(() => {
+          resumeInFlight.current = false;
+        });
+    };
+
+    resumeIfNeeded(AppState.currentState);
+    const subscription = AppState.addEventListener("change", resumeIfNeeded);
+
+    return () => subscription.remove();
+  }, [asleep.isRecoveryRequired, asleep.resumeTracking]);
+}
+```
+
+### 오류 category별 처리
+
+| `error.category` | native 상태 | 앱 처리 |
+|---|---|---|
+| `recoveryRequired` | session은 살아 있고 foreground 복구 필요 | iOS foreground에서 `resumeTracking()`, 이후 upload로 복구 확인 |
+| `recordingDead` | recorder는 종료됐지만 session은 열려 있음 | `stopTracking()` 성공 후 새 측정 |
+| `terminal` | session이 종료됐으며 close 이벤트가 오지 않을 수 있음 | 앱의 기존 session 상태를 정리하고 새 측정 |
+| `transient` | session이 유지됨 | 측정을 유지하고 이후 upload와 상태 관찰 |
+| `unknown` | 분류되지 않음 | 정상으로 가정하지 말고 오류 전체를 기록 |
+
+문자열 message나 iOS enum 순번이 아니라 `error.code`와 `error.category`로 분기하세요. native SDK의 문서화된 숫자 코드가 필요하면 `error.sdkCode`를 사용합니다. 원본 오류는 `error.cause`에 보존됩니다.
+
+## 7. 분석 결과와 리포트
+
+### 실시간 분석
+
+`requestAnalysis()`의 Promise 반환 형태는 플랫폼마다 다르지만, reactive `analysisResult`는 두 플랫폼 모두 `onAnalysisResult` 이벤트만 갱신합니다. 앱의 공통 UI는 Promise 결과보다 `analysisResult`를 구독하는 편이 안전합니다.
+
+| 플랫폼 | `requestAnalysis()` 반환 | 공통 상태 갱신 |
+|---|---|---|
+| Android | `AsleepAnalysisResult` | `onAnalysisResult` → `analysisResult` |
+| iOS | `AsleepAnalysisAck` | `onAnalysisResult` → `analysisResult` |
+
+Android에서 Promise 결과를 별도로 store에 다시 쓰면 같은 분석에 대해 중복 update가 발생할 수 있습니다.
+
+### 완료 리포트
+
+| API | 반환 |
+|---|---|
+| `getReport(sessionId)` | 단일 `AsleepReport` |
+| `getReportList(fromDate, toDate)` | `AsleepSession[]` |
+| `getAverageReport(fromDate, toDate)` | `AsleepAverageReport` |
+| `deleteSession(sessionId)` | session 삭제 완료 |
+
+모든 조회 실패는 `AsleepError`로 throw됩니다. 네이티브 코드가 리포트 payload 없이 resolve하면 wrapper가 `REPORT_NOT_FOUND`를 생성하지만, 플랫폼 SDK의 실패는 Android의 `REPORT_ERROR`처럼 다른 `AsleepError.code`로 도착할 수 있습니다. 모든 리포트 오류를 일괄 재시도하지 마세요. 앱이 실제로 확인한 미생성 리포트 조건만 제한적으로 재시도하고, 네트워크·인증을 비롯한 다른 실패는 그대로 노출해야 합니다.
+
+`getReportList()`는 현재 native SDK에서 최대 100개를 반환하며 별도 pagination API는 없습니다. 날짜는 `YYYY-MM-DD` 형식으로 전달하세요.
+
+재시도 횟수, 간격, backoff, 취소와 사용자 안내는 앱 정책입니다.
+
+## 8. 프로덕션 체크리스트
+
+### 빌드와 설정
+
+- [ ] SDK 버전을 의도적으로 고정하고 업그레이드 시 CHANGELOG 확인
+- [ ] 설치 또는 버전 변경 후 iOS/Android 네이티브 빌드 생성
+- [ ] iOS 마이크 설명과 `UIBackgroundModes: ["audio"]` 확인
+- [ ] Android merged manifest에 foreground service와 필요한 권한이 포함됐는지 확인
+- [ ] API key가 소스와 로그에 노출되지 않는지 확인
+
+### cold start와 권한
+
+- [ ] 앱 데이터와 권한을 지운 실제 기기에서 첫 실행
+- [ ] 마이크 허용, 거절, 다시 허용하는 흐름
+- [ ] Android 13 이상 알림 거절 상태에서 측정과 알림 UX 확인
+- [ ] Android 배터리 최적화 설정을 연 뒤 앱 복귀 시 상태 재확인
+
+### 수명 주기와 복구
+
+- [ ] `checkAndRestoreTracking()` → `initAsleepConfig()` → `checkBatteryOptimization()` 순서 확인
+- [ ] 활성 session 복원 뒤에도 `initAsleepConfig()`가 실행되는지 확인
+- [ ] 활성 session에서 `startTracking()`을 중복 호출하지 않는지 확인
+- [ ] Android 앱 process 종료 후 foreground service session 복원
+- [ ] iOS 오디오 중단 후 foreground `resumeTracking()`과 다음 upload 확인
+- [ ] `recordingDead`에서 `stopTracking()` 후 새 측정
+- [ ] `terminal`, `transient`, `unknown` 오류 분기 확인
+- [ ] listener와 `Asleep.initialize()` teardown 누락이 없는지 확인
+
+### 데이터와 장시간 측정
+
+- [ ] Android와 iOS의 `requestAnalysis()` 반환 차이 확인
+- [ ] `analysisResult`를 이벤트 기반으로 한 번만 갱신
+- [ ] 정상적인 빈 리포트 목록과 조회 실패를 구분
+- [ ] 두 플랫폼에서 미생성 리포트와 네트워크·인증 등 다른 실패를 구분
+- [ ] 지원하는 대표 iOS/Android 실제 기기에서 백그라운드 장시간 측정 완료
+
+시뮬레이터의 오디오 동작이나 warm start만으로 출시 가능 여부를 판단하지 마세요. 권한이 없는 cold start, process 복원, 실제 백그라운드 장시간 측정이 각각 필요합니다.
+
+## 참고
+
+- [SDK README](../README.ko.md)
+- [English Integration Guide](./INTEGRATION.md)
+- [Asleep 개발자 문서](https://docs.asleep.ai)

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -12,7 +12,7 @@ The examples use service-based sleep tracking through `initAsleepConfig()`. ODA 
 flowchart LR
     A["App starts"] --> B["Mount useAsleep or initialize listeners"]
     B --> C["checkAndRestoreTracking()"]
-    C --> D["initAsleepConfig() always"]
+    C --> D["initAsleepConfig() and wait for iOS user event"]
     D --> E["checkBatteryOptimization()"]
     E --> F{"Android service restored?"}
     F -- "Yes" --> G["Render restored SDK state"]
@@ -87,8 +87,9 @@ releaseListeners();
 Run this sequence once from the app-level integration owner:
 
 ```tsx
+import { Platform } from "react-native";
 import { useCallback } from "react";
-import { useAsleep } from "react-native-asleep";
+import { AsleepError, useAsleep } from "react-native-asleep";
 
 export function useSleepTrackingBootstrap(stableUserId?: string) {
   const asleep = useAsleep();
@@ -96,10 +97,46 @@ export function useSleepTrackingBootstrap(stableUserId?: string) {
   const initialize = useCallback(async () => {
     const restoration = await asleep.checkAndRestoreTracking();
 
-    await asleep.initAsleepConfig({
+    const config = {
       apiKey: "YOUR_API_KEY",
       userId: stableUserId,
-    });
+    };
+
+    if (Platform.OS === "ios") {
+      let removeJoined = () => {};
+      let removeFailed = () => {};
+      const configurationFinished = new Promise<void>((resolve, reject) => {
+        removeJoined = asleep.addEventListener("onUserJoined", () => resolve());
+        removeFailed = asleep.addEventListener(
+          "onUserJoinFailed",
+          (failure) => {
+            reject(
+              new AsleepError(
+                "USER_JOIN_FAILED",
+                failure.detail ?? failure.error ?? "User join failed.",
+                {
+                  sdkCode: failure.sdkCode,
+                  caseName: failure.caseName,
+                  cause: failure,
+                },
+              ),
+            );
+          },
+        );
+      });
+
+      try {
+        await Promise.all([
+          asleep.initAsleepConfig(config),
+          configurationFinished,
+        ]);
+      } finally {
+        removeJoined();
+        removeFailed();
+      }
+    } else {
+      await asleep.initAsleepConfig(config);
+    }
 
     const battery = await asleep.checkBatteryOptimization();
 
@@ -110,6 +147,7 @@ export function useSleepTrackingBootstrap(stableUserId?: string) {
   }, [
     asleep.checkAndRestoreTracking,
     asleep.initAsleepConfig,
+    asleep.addEventListener,
     asleep.checkBatteryOptimization,
     stableUserId,
   ]);
@@ -122,6 +160,8 @@ export function useSleepTrackingBootstrap(stableUserId?: string) {
 
 - `checkAndRestoreTracking()` asks Android native code whether tracking survived the JavaScript process and reconnects the service when needed. On iOS, the method is a required cross-platform prerequisite but returns `{ hasActiveSession: false }`; iOS has no persistent service to reconnect.
 - `initAsleepConfig()` remains required after that check. A restored session does not mean the current JavaScript process has configured the SDK and report APIs.
+- On iOS, the bridge call starts asynchronous user configuration and can return before the native tracking and report managers exist. Register `onUserJoined` and `onUserJoinFailed` before calling it, then wait for one of those events. On Android, await the action itself; the restored-service fast path resolves without emitting `onUserJoined`.
+- Do not use `isSetupComplete` alone as the iOS readiness signal. The current bridge action can update it before the user-join delegate creates the native managers.
 - `checkBatteryOptimization()` marks the required prerequisite as checked. On iOS it resolves with `{ exempted: true, platform: "ios" }`.
 - `startTracking()` rejects with `MISSING_PREREQUISITE` if restoration or the battery check has not run.
 
@@ -165,9 +205,23 @@ async function startSleepTracking() {
 
   return { status: "started" as const };
 }
+
+async function handleTrackingPress() {
+  const shouldStop =
+    asleep.isTracking || asleep.error?.category === "recordingDead";
+
+  if (shouldStop) {
+    await asleep.stopTracking();
+    return { status: "stopped" as const };
+  }
+
+  return startSleepTracking();
+}
 ```
 
 When Android opens battery settings, the result only means the settings flow was requested. Recheck `checkBatteryOptimization()` after the app returns and let the user retry. `startTracking()` performs its own Android exemption check and throws `BATTERY_NOT_EXEMPTED` if the device is still not exempted.
+
+Use the same `shouldStop` predicate for the primary button label and action. In the `recordingDead` state, `isTracking` is `false` but the native session is still open, so the app must stop that session instead of starting another one.
 
 On Android 13 and later, `requestRequiredPermissions()` also requests notification permission for foreground-service visibility. Its boolean result reflects microphone-side permissions, matching `hasRequiredPermissions()`; notification denial alone does not prevent tracking.
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,386 @@
+# React Native Asleep Integration Guide
+
+[English](./INTEGRATION.md) | [한국어](./INTEGRATION.ko.md)
+
+This guide covers production integration of `react-native-asleep` in React Native and Expo apps. It expands on the [README](../README.md) with restoration, lifecycle ownership, platform differences, recovery, analysis, reports, and release verification.
+
+The examples use service-based sleep tracking through `initAsleepConfig()`. ODA (On-Device Analysis) is outside this guide: `setup()` configures a new ODA session and cannot run while a restored session is tracking.
+
+## Integration flow
+
+```mermaid
+flowchart LR
+    A["App starts"] --> B["Mount useAsleep or initialize listeners"]
+    B --> C["checkAndRestoreTracking()"]
+    C --> D["initAsleepConfig() always"]
+    D --> E["checkBatteryOptimization()"]
+    E --> F{"Android service restored?"}
+    F -- "Yes" --> G["Render restored SDK state"]
+    F -- "No" --> H["User starts tracking"]
+    H --> I["Check and request permission"]
+    I --> J["Recheck Android battery exemption"]
+    J --> K["startTracking()"]
+    G --> L["Observe state and events"]
+    K --> L
+    L --> M["stopTracking()"]
+    M --> N["Fetch report when ready"]
+```
+
+Three rules prevent most integration failures:
+
+1. Complete the Android service-restoration check before configuration, and always configure afterward—even when it finds a live session.
+2. Request runtime permissions only from a user action. `startTracking()` checks permissions but does not request them.
+3. Treat the SDK state as native facts. Keep product workflow, persistence, timers, retries, UI, and analytics in the app.
+
+## 1. Installation and native configuration
+
+Follow the [README installation instructions](../README.md#installation) and [native configuration](../README.md#native-configuration).
+
+Because the package contains native modules:
+
+- rebuild the development or store binary after installation or a version change;
+- do not validate it with Expo Go;
+- do not expect an OTA update alone to install a new native SDK.
+
+The app must provide iOS microphone usage text and the audio background mode. Android permissions and the foreground service come from the library manifest.
+
+## 2. Own the listener lifecycle
+
+### React applications
+
+Mount `useAsleep()` in the integration owner that coordinates app-wide sleep tracking. The hook attaches native listeners on mount and releases them on unmount.
+
+The listener bridge is ref-counted, so additional components may also use the hook without creating competing SDK stores. Keeping one app-level integration hook is still useful because it gives product workflow a single owner.
+
+Importing `react-native-asleep` is side-effect-free; it does not attach listeners.
+
+### Non-React code
+
+Call `Asleep.initialize()` before relying on state or native events where no mounted hook owns the bridge. Always call the returned cleanup function.
+
+```ts
+import { Asleep } from "react-native-asleep";
+
+const releaseListeners = Asleep.initialize();
+
+const unsubscribe = Asleep.subscribe((state) => {
+  console.log(state.status);
+});
+
+const removeAnalysisListener = Asleep.addEventListener(
+  "onAnalysisResult",
+  (result) => {
+    console.log(result);
+  },
+);
+
+// When the owner is disposed:
+removeAnalysisListener();
+unsubscribe();
+releaseListeners();
+```
+
+`Asleep.initialize()` is also ref-counted, so it can coexist with mounted `useAsleep()` hooks.
+
+## 3. Restore, then configure
+
+Run this sequence once from the app-level integration owner:
+
+```tsx
+import { useCallback } from "react";
+import { useAsleep } from "react-native-asleep";
+
+export function useSleepTrackingBootstrap(stableUserId?: string) {
+  const asleep = useAsleep();
+
+  const initialize = useCallback(async () => {
+    const restoration = await asleep.checkAndRestoreTracking();
+
+    await asleep.initAsleepConfig({
+      apiKey: "YOUR_API_KEY",
+      userId: stableUserId,
+    });
+
+    const battery = await asleep.checkBatteryOptimization();
+
+    return {
+      hasActiveSession: restoration.hasActiveSession,
+      battery,
+    };
+  }, [
+    asleep.checkAndRestoreTracking,
+    asleep.initAsleepConfig,
+    asleep.checkBatteryOptimization,
+    stableUserId,
+  ]);
+
+  return { ...asleep, initialize };
+}
+```
+
+### Why this order is required
+
+- `checkAndRestoreTracking()` asks Android native code whether tracking survived the JavaScript process and reconnects the service when needed. On iOS, the method is a required cross-platform prerequisite but returns `{ hasActiveSession: false }`; iOS has no persistent service to reconnect.
+- `initAsleepConfig()` remains required after that check. A restored session does not mean the current JavaScript process has configured the SDK and report APIs.
+- `checkBatteryOptimization()` marks the required prerequisite as checked. On iOS it resolves with `{ exempted: true, platform: "ios" }`.
+- `startTracking()` rejects with `MISSING_PREREQUISITE` if restoration or the battery check has not run.
+
+Do not run restoration and configuration concurrently. Do not skip configuration when `hasActiveSession` is `true`.
+
+If initialization fails, keep tracking controls disabled and offer an app-owned retry action. Do not convert the failure into an apparently ready state.
+
+Do not commit the API key to source control. Load it through the secret or configuration mechanism used by the app's build environment.
+
+### Stable user identity
+
+If the app supplies `userId`, persist the stable identifier in app storage and reuse it on later initialization. The SDK exposes the current native `userId`, but account mapping and guest-to-member policy belong to the app.
+
+Do not reconfigure a live session with a different product identity. Define any identity migration policy outside the SDK.
+
+## 4. Check prerequisites and start
+
+Permission prompts must originate from a user-driven interaction:
+
+```ts
+async function startSleepTracking() {
+  if (!(await asleep.hasRequiredPermissions())) {
+    const granted = await asleep.requestRequiredPermissions();
+    if (!granted) return { status: "permissionDenied" as const };
+  }
+
+  const battery = await asleep.checkBatteryOptimization();
+  if (!battery.exempted) {
+    await asleep.requestBatteryOptimizationExemption();
+    return { status: "batterySettingsOpened" as const };
+  }
+
+  await asleep.startTracking({
+    android: {
+      notification: {
+        title: "Sleep tracking",
+        text: "Sleep analysis is running.",
+      },
+    },
+  });
+
+  return { status: "started" as const };
+}
+```
+
+When Android opens battery settings, the result only means the settings flow was requested. Recheck `checkBatteryOptimization()` after the app returns and let the user retry. `startTracking()` performs its own Android exemption check and throws `BATTERY_NOT_EXEMPTED` if the device is still not exempted.
+
+On Android 13 and later, `requestRequiredPermissions()` also requests notification permission for foreground-service visibility. Its boolean result reflects microphone-side permissions, matching `hasRequiredPermissions()`; notification denial alone does not prevent tracking.
+
+The app owns permission-denied screens, settings guidance, retry buttons, and analytics. The library never renders UI.
+
+## 5. Separate SDK state from app state
+
+| SDK-owned native facts | App-owned product state |
+|---|---|
+| `status`, `isTracking`, `isTrackingPaused` | Bootstrap or screen readiness |
+| `isRecoveryRequired`, `error` | Permission education and retry UI |
+| `sessionId`, `userId` | Persisted identity mapping |
+| `analysisResult`, `isAnalyzing` | Wall-clock tracking start time and duration |
+| `didClose`, `isSetupComplete`, `isODAEnabled` | Alarm, widget, Live Activity, cloud sync |
+| Native event and action transitions | Business retry policy and observability severity |
+
+`status` is the lifecycle source:
+
+| `status` | Meaning |
+|---|---|
+| `idle` | No projected live tracking session |
+| `tracking` | Tracking is active |
+| `paused` | The live native session is interrupted |
+| `recoveryRequired` | The live iOS session needs an explicit foreground resume |
+
+`isTracking` is derived from `status` and is `true` for `tracking`, `paused`, and `recoveryRequired`. Do not store a competing app boolean for the same fact.
+
+The SDK does not expose wall-clock tracking duration. Store a start timestamp in the app and compute `now - startedAt`; do not count timer ticks because background suspension makes them inaccurate.
+
+## 6. Platform behavior
+
+| Concern | Android | iOS |
+|---|---|---|
+| Background operation | Foreground service with a persistent notification | Audio background mode |
+| Cold restoration | `checkAndRestoreTracking()` reconnects the live service | No persistent service; the check returns `false` |
+| Battery prerequisite | Exemption is required and checked again by `startTracking()` | Check resolves as exempted |
+| Runtime permissions | Microphone; notification is also requested on API 33+ | Microphone |
+| Interruption recovery | `resumeTracking()` is unsupported | `resumeTracking()` is available |
+| `requestAnalysis()` promise | Full analysis payload | `{ status: "requested", timestamp }` acknowledgement |
+| Reactive analysis | `onAnalysisResult`, normalized to camelCase | `onAnalysisResult` |
+
+### Android foreground behavior
+
+Pass notification text to `startTracking()` rather than configuring a separate notification API. The notification is part of the long-running recording service.
+
+Test cold restoration by starting tracking, terminating the app process without ending the native session, reopening the app, and verifying that `checkAndRestoreTracking()` reconnects before configuration continues.
+
+### iOS interruption recovery
+
+A phone call, audio-session conflict, or failed background activation can interrupt recording. When `isRecoveryRequired` is `true`, call `resumeTracking()` after the app enters the foreground.
+
+Use an app-owned in-flight guard so repeated foreground events do not issue concurrent resume calls:
+
+```tsx
+import { useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import { useAsleep } from "react-native-asleep";
+
+export function useAsleepForegroundRecovery() {
+  const asleep = useAsleep();
+  const resumeInFlight = useRef(false);
+
+  useEffect(() => {
+    const resumeIfNeeded = (appState: string) => {
+      if (
+        appState !== "active" ||
+        !asleep.isRecoveryRequired ||
+        resumeInFlight.current
+      ) {
+        return;
+      }
+
+      resumeInFlight.current = true;
+      void asleep
+        .resumeTracking()
+        .catch(() => {
+          // The classified failure is available reactively as asleep.error.
+        })
+        .finally(() => {
+          resumeInFlight.current = false;
+        });
+    };
+
+    resumeIfNeeded(AppState.currentState);
+    const subscription = AppState.addEventListener("change", resumeIfNeeded);
+
+    return () => subscription.remove();
+  }, [asleep.isRecoveryRequired, asleep.resumeTracking]);
+}
+```
+
+A resolved `resumeTracking()` promise means the resume request was accepted; it does not prove audio upload has recovered. The SDK keeps `status === "recoveryRequired"` until a later successful upload changes it back to `"tracking"`.
+
+`resumeTracking()` is iOS-only and throws `UNSUPPORTED_PLATFORM` on Android.
+
+## 7. Handle structured errors
+
+All actions and queries reject with `AsleepError`. Do not use `null`, an empty array, or parsed message text as a generic error channel.
+
+```ts
+import { AsleepError } from "react-native-asleep";
+
+try {
+  await asleep.startTracking();
+} catch (cause: unknown) {
+  if (!(cause instanceof AsleepError)) throw cause;
+
+  console.log({
+    code: cause.code,
+    category: cause.category,
+    sdkCode: cause.sdkCode,
+    caseName: cause.caseName,
+  });
+}
+```
+
+Tracking-runtime failures carry an objective recovery classification:
+
+| `error.category` | Native state | Required integration behavior |
+|---|---|---|
+| `terminal` | The session is already gone and a separate close event may not follow | Clear app-owned live-session state and allow a new session |
+| `recordingDead` | The recorder stopped, but the native session remains open | Call `stopTracking()` to close it, then start a new session |
+| `recoveryRequired` | The iOS session remains live | Call `resumeTracking()` in the foreground and wait for a successful upload |
+| `transient` | The session survived | Keep tracking and observe later state/events |
+| `unknown` | Not safely classified | Record the error and do not assume tracking is healthy |
+
+Only tracking-runtime failures are guaranteed to have `category`; precondition, setup, permission, report, and other action errors may leave it undefined. Use the stable `code` for action-specific behavior.
+
+Do not call `stopTracking()` only because `isTracking` became `false`: terminal failures already closed their session. The demonstrated exception is `recordingDead`, where `isTracking` is false but `stopTracking()` is required because native recording stopped without closing the session.
+
+Forward the `AsleepError` itself to observability so `cause`, `sdkCode`, and `caseName` remain available. The app decides log severity; the SDK only reports the recovery fact.
+
+## 8. Stop tracking and read reports
+
+`stopTracking()` closes the active session and marks the public state closed. The final `sessionId` may also arrive through the native close event. Product cleanup—alarms, app timers, cloud state, and navigation—belongs to the app and should occur only after the SDK stop succeeds or a terminal event proves the session is gone.
+
+Report generation may lag behind session close. The wrapper produces `REPORT_NOT_FOUND` when native code resolves without a report payload, but platform SDK failures can arrive under another `AsleepError.code` such as Android `REPORT_ERROR`. Do not blanket-retry every report failure. Until all native not-found codes are normalized by the wrapper, choose retry behavior only for error cases the app has explicitly verified; keep network, authentication, and other failures visible.
+
+Report APIs:
+
+| Action | Result |
+|---|---|
+| `getReport(sessionId)` | One `AsleepReport`; may throw `REPORT_NOT_FOUND` when native resolves no payload |
+| `getReportList(fromDate, toDate)` | `AsleepSession[]`; an empty array is a valid result |
+| `getAverageReport(fromDate, toDate)` | `AsleepAverageReport`; may throw `REPORT_NOT_FOUND` when native resolves no payload |
+| `deleteSession(sessionId)` | Deletes a session or throws |
+
+`getReportList()` currently returns at most 100 sessions and has no public pagination API. Pass dates as `YYYY-MM-DD`.
+
+## 9. Consume analysis consistently
+
+`requestAnalysis()` has different promise results:
+
+- Android resolves with the analysis payload and also emits `onAnalysisResult`.
+- iOS resolves with `{ status: "requested", timestamp }`; the result arrives later through `onAnalysisResult`.
+
+For cross-platform UI, read `analysisResult` and `isAnalyzing` from `useAsleep()` or subscribe to `onAnalysisResult`. The event transition is the only writer of reactive `analysisResult`, preventing an Android promise and event from updating state twice.
+
+```tsx
+import { useAsleep } from "react-native-asleep";
+
+export function useLiveSleepAnalysis() {
+  const { analysisResult, isAnalyzing, requestAnalysis } = useAsleep();
+
+  async function refresh() {
+    await requestAnalysis();
+    // Read `analysisResult`; the promise is not the cross-platform result.
+  }
+
+  return { analysisResult, isAnalyzing, refresh };
+}
+```
+
+Android snake_case event payloads are normalized to camelCase before they reach `analysisResult`.
+
+## 10. Keep optional product features outside the SDK
+
+These concerns are intentionally app-owned:
+
+- account authentication and cloud synchronization;
+- alarms, widgets, Live Activities, and notifications unrelated to the Android tracking service;
+- report-derived labels, timeline slots, and product metrics;
+- persistent storage and wall-clock duration;
+- permission-denied UI and retry policy;
+- analytics and observability.
+
+Integrate them around SDK state and events. Their failure should not silently skip or replace the SDK's required start, stop, restore, or recovery operations.
+
+## Production checklist
+
+- [ ] Install an exact package version and create a new native build.
+- [ ] Verify the API key and initialization-failure UI.
+- [ ] Test a cold start with no granted permissions.
+- [ ] Test microphone denial and a later successful request from a user action.
+- [ ] On Android 13+, test both notification grant and denial.
+- [ ] Verify the Android foreground-service notification.
+- [ ] Verify battery exemption, settings return, and the second check.
+- [ ] On Android, start tracking, kill the JavaScript app process, reopen it, and restore the live session.
+- [ ] Verify `initAsleepConfig()` still runs after an Android session is restored.
+- [ ] Keep tracking through background and foreground transitions.
+- [ ] On iOS, trigger an audio interruption and verify foreground recovery through a later upload.
+- [ ] Verify each handled error category against its documented action.
+- [ ] Verify `recordingDead` closes the remaining native session before restart.
+- [ ] Verify a terminal failure does not wait for or synthesize a second close event.
+- [ ] Stop tracking and verify the app distinguishes a pending report from network, authentication, and other failures on both platforms.
+- [ ] Verify analysis UI from `analysisResult` on both platforms.
+- [ ] Run a full-night-length session on representative physical iOS and Android devices.
+
+Simulator audio behavior and warm-path testing alone are not sufficient release evidence.
+
+## References
+
+- [SDK README](../README.md)
+- [Example app](https://github.com/asleep-ai/asleep-sdk-react-native/tree/main/example)
+- [Asleep developer documentation](https://docs.asleep.ai)
+- [GitHub issues](https://github.com/asleep-ai/asleep-sdk-react-native/issues)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "expo-module.config.json",
     "*.podspec",
     "LICENSE.md",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "docs/INTEGRATION.md",
+    "docs/INTEGRATION.ko.md"
   ],
   "devDependencies": {
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary

`README.md` remains a concise English onboarding document for first-time SDK users. This change adds a Korean mirror and separate bilingual production integration guides, while correcting lifecycle guidance against the SDK source and regression tests.

## Key changes

- Add English/Korean switching across the README and integration guides.
- Document the service-mode bootstrap flow as restore, then configure, with permission and battery-optimization checks.
- Cover Android foreground-service restoration, iOS interruption recovery, error categories, and report timing in the production guides.
- Add v1-to-v2 migration guidance for the lean `useAsleep` and `Asleep` API surface.
- Include the four public documentation files in the npm package while excluding maintainer-only publishing documentation and the example app.

## Type of change

- Documentation

## Testing performed

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`: 7 suites, 109 tests
- `markdown-link-check` on `README.md`, `README.ko.md`, `docs/INTEGRATION.md`, and `docs/INTEGRATION.ko.md`
- `npm pack --dry-run`: verified all four public docs are included and `docs/PUBLISHING.md` plus `example/` are excluded
- Independent review: ready

## Related issues

None.